### PR TITLE
FE no longer send sort order & sort by, used this by default

### DIFF
--- a/core-service/src/repositories/mysql/mysql_event.go
+++ b/core-service/src/repositories/mysql/mysql_event.go
@@ -89,11 +89,7 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 		query = query + ` AND date BETWEEN '` + params.StartDate + `' AND '` + params.EndDate + `'`
 	}
 
-	if params.SortBy != "" {
-		query = query + ` ORDER BY date, ` + params.SortBy + ` , priority ` + params.SortOrder
-	} else {
-		query = query + ` ORDER BY created_at DESC`
-	}
+	query = query + ` ORDER BY date, start_hour, priority DESC `
 
 	query = query + ` LIMIT ?,? `
 


### PR DESCRIPTION
Overview:
- Front End no longer send params sort_order and sort_by, used this by default by API

@jabardigitalservice/jds-backend 

Evidence:
project: Portal Jabar
title: Default API sorting
participants: @novansyaah @khihadysucahyo @f1reFr0st @firmanalamsyah580 @sandisunandar @firman_desadigital