### PR TITLE
add http error handler

### DIFF
--- a/core-service/src/cmd/main.go
+++ b/core-service/src/cmd/main.go
@@ -32,7 +32,7 @@ func main() {
 	}()
 
 	e := echo.New()
-	e.HTTPErrorHandler = httpDelivery.HttpErrorHandler
+	e.HTTPErrorHandler = httpDelivery.ErrorHandler
 	middL := middl.InitMiddleware()
 	e.Use(middleware.CORSWithConfig(cfg.Cors))
 	e.Use(middL.SENTRY)

--- a/core-service/src/cmd/main.go
+++ b/core-service/src/cmd/main.go
@@ -32,6 +32,7 @@ func main() {
 	}()
 
 	e := echo.New()
+	e.HTTPErrorHandler = httpDelivery.HttpErrorHandler
 	middL := middl.InitMiddleware()
 	e.Use(middleware.CORSWithConfig(cfg.Cors))
 	e.Use(middL.SENTRY)

--- a/core-service/src/delivery/http/event_handler.go
+++ b/core-service/src/delivery/http/event_handler.go
@@ -34,7 +34,7 @@ func (h *EventHandler) Fetch(c echo.Context) error {
 	listEvent, total, err := h.EventUcase.Fetch(ctx, &params)
 
 	if err != nil {
-		return c.JSON(getStatusCode(err), &ResponseError{Message: err.Error()})
+		return err
 	}
 
 	listEventRes := []domain.ListEventResponse{}

--- a/core-service/src/delivery/http/featured_program_handler.go
+++ b/core-service/src/delivery/http/featured_program_handler.go
@@ -26,7 +26,7 @@ func (h *FeaturedProgramHandler) FetchFeaturedPrograms(c echo.Context) error {
 	featuredProgramsList, err := h.FPUsecase.Fetch(ctx)
 
 	if err != nil {
-		return c.JSON(getStatusCode(err), &ResponseError{Message: err.Error()})
+		return err
 	}
 
 	data := map[string]interface{}{"data": featuredProgramsList}

--- a/core-service/src/delivery/http/feedback_handler.go
+++ b/core-service/src/delivery/http/feedback_handler.go
@@ -46,7 +46,7 @@ func (h *FeedbackHandler) Store(c echo.Context) (err error) {
 	ctx := c.Request().Context()
 	err = h.FUsecase.Store(ctx, f)
 	if err != nil {
-		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
+		return err
 	}
 
 	return c.JSON(http.StatusCreated, f)

--- a/core-service/src/delivery/http/handlers.go
+++ b/core-service/src/delivery/http/handlers.go
@@ -18,8 +18,8 @@ func NewHandler(e *echo.Group, r *echo.Group, u *usecases.Usecases) {
 	NewFeaturedProgramHandler(e, r, u.FeaturedProgramUcase)
 }
 
-// HttpErrorHandler ...
-func HttpErrorHandler(err error, c echo.Context) {
+// ErrorHandler ...
+func ErrorHandler(err error, c echo.Context) {
 	report, ok := err.(*echo.HTTPError)
 	if !ok {
 		report = echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/core-service/src/delivery/http/handlers.go
+++ b/core-service/src/delivery/http/handlers.go
@@ -1,6 +1,9 @@
 package http
 
 import (
+	"net/http"
+
+	"github.com/getsentry/sentry-go"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/usecases"
 	"github.com/labstack/echo/v4"
 )
@@ -13,4 +16,15 @@ func NewHandler(e *echo.Group, r *echo.Group, u *usecases.Usecases) {
 	NewEventHandler(e, r, u.EventUcase)
 	NewFeedbackHandler(e, r, u.FeedbackUcase)
 	NewFeaturedProgramHandler(e, r, u.FeaturedProgramUcase)
+}
+
+// HttpErrorHandler ...
+func HttpErrorHandler(err error, c echo.Context) {
+	report, ok := err.(*echo.HTTPError)
+	if !ok {
+		report = echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	sentry.CaptureException(err)
+	c.Logger().Error(report)
+	c.JSON(report.Code, report)
 }

--- a/core-service/src/delivery/http/informations_handler.go
+++ b/core-service/src/delivery/http/informations_handler.go
@@ -33,7 +33,7 @@ func (h *InformationHandler) Fetch(c echo.Context) error {
 	listInformations, total, err := h.InformationsUcase.Fetch(ctx, &params)
 
 	if err != nil {
-		return c.JSON(getStatusCode(err), &ResponseError{Message: err.Error()})
+		return err
 	}
 
 	res := Paginate(c, listInformations, total, params)

--- a/core-service/src/delivery/http/news_handler.go
+++ b/core-service/src/delivery/http/news_handler.go
@@ -40,7 +40,7 @@ func (h *NewsHandler) FetchNews(c echo.Context) error {
 	listNews, total, err := h.CUsecase.Fetch(ctx, &params)
 
 	if err != nil {
-		return c.JSON(getStatusCode(err), &ResponseError{Message: err.Error()})
+		return err
 	}
 
 	// Copy slice to slice

--- a/core-service/src/delivery/http/unit_handler.go
+++ b/core-service/src/delivery/http/unit_handler.go
@@ -34,7 +34,7 @@ func (h *UnitHandler) FetchUnits(c echo.Context) error {
 	listUnit, total, err := h.UUsecase.Fetch(ctx, &params)
 
 	if err != nil {
-		return c.JSON(getStatusCode(err), &ResponseError{Message: err.Error()})
+		return err
 	}
 
 	// Copy slice to slice


### PR DESCRIPTION
## Changes
- Add http error handler
- http handler: returning error exception instead of json return

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: Add http error handler
participants: @khihadysucahyo @novansyaah @firmanJS @ayocodingit 
