### PR TITLE
add filter featured program with json search sql

### DIFF
--- a/core-service/src/database/migrations/1629281242_initialize_schema.up.sql
+++ b/core-service/src/database/migrations/1629281242_initialize_schema.up.sql
@@ -192,6 +192,7 @@ CREATE TABLE featured_programs (
   updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id)
 );
+CREATE INDEX idx_categories_program on featured_programs (categories);
 
 DROP TABLE IF EXISTS tags;
 CREATE TABLE tags (

--- a/core-service/src/domain/featured_program.go
+++ b/core-service/src/domain/featured_program.go
@@ -32,10 +32,10 @@ type SocialMedia struct {
 
 // FeaturedProgramUsecase represent the featured program usecases
 type FeaturedProgramUsecase interface {
-	Fetch(ctx context.Context) ([]FeaturedProgram, error)
+	Fetch(ctx context.Context, params *Request) ([]FeaturedProgram, error)
 }
 
 // FeaturedProgramRepository represent the featured program repository contract
 type FeaturedProgramRepository interface {
-	Fetch(ctx context.Context) (fp []FeaturedProgram, err error)
+	Fetch(ctx context.Context, params *Request) (fp []FeaturedProgram, err error)
 }

--- a/core-service/src/modules/featured-program/delivery/http/featured_program_handler.go
+++ b/core-service/src/modules/featured-program/delivery/http/featured_program_handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
 )
 
 // FeaturedProgramHandler ...
@@ -23,7 +24,12 @@ func NewFeaturedProgramHandler(e *echo.Group, r *echo.Group, us domain.FeaturedP
 func (h *FeaturedProgramHandler) FetchFeaturedPrograms(c echo.Context) error {
 
 	ctx := c.Request().Context()
-	featuredProgramsList, err := h.FPUsecase.Fetch(ctx)
+	params := helpers.GetRequestParams(c)
+	params.Filters = map[string]interface{}{
+		"categories": c.QueryParam("categories"),
+	}
+
+	featuredProgramsList, err := h.FPUsecase.Fetch(ctx, &params)
 
 	if err != nil {
 		return err

--- a/core-service/src/modules/featured-program/delivery/http/featured_program_handler.go
+++ b/core-service/src/modules/featured-program/delivery/http/featured_program_handler.go
@@ -26,7 +26,7 @@ func (h *FeaturedProgramHandler) FetchFeaturedPrograms(c echo.Context) error {
 	ctx := c.Request().Context()
 	params := helpers.GetRequestParams(c)
 	params.Filters = map[string]interface{}{
-		"categories": c.QueryParam("categories"),
+		"categories": c.QueryParam("cat"),
 	}
 
 	featuredProgramsList, err := h.FPUsecase.Fetch(ctx, &params)

--- a/core-service/src/modules/featured-program/repository/mysql/mysql_featured_program.go
+++ b/core-service/src/modules/featured-program/repository/mysql/mysql_featured_program.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 
@@ -58,9 +59,13 @@ func (m *mysqlFeaturedProgramRepository) fetch(ctx context.Context, query string
 	return result, nil
 }
 
-func (m *mysqlFeaturedProgramRepository) Fetch(ctx context.Context) (res []domain.FeaturedProgram, err error) {
+func (m *mysqlFeaturedProgramRepository) Fetch(ctx context.Context, params *domain.Request) (res []domain.FeaturedProgram, err error) {
 
-	query := `SELECT id, title, excerpt, description, organization, categories, service_type, websites, social_media, logo FROM featured_programs limit 50`
+	query := `SELECT id, title, excerpt, description, organization, categories, service_type, websites, social_media, logo FROM featured_programs WHERE 1=1`
+
+	if v, ok := params.Filters["categories"]; ok && v != "" {
+		query = fmt.Sprintf(`%s AND json_search(categories, 'all', '%s') is not null limit 50`, query, v)
+	}
 
 	res, err = m.fetch(ctx, query)
 

--- a/core-service/src/modules/featured-program/usecase/featured_program_ucase.go
+++ b/core-service/src/modules/featured-program/usecase/featured_program_ucase.go
@@ -20,12 +20,12 @@ func NewFeaturedProgramUsecase(p domain.FeaturedProgramRepository, timeout time.
 	}
 }
 
-func (u *featuredProgramUsecase) Fetch(c context.Context) (res []domain.FeaturedProgram, err error) {
+func (u *featuredProgramUsecase) Fetch(c context.Context, params *domain.Request) (res []domain.FeaturedProgram, err error) {
 
 	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
 	defer cancel()
 
-	res, err = u.featuredProgramRepo.Fetch(ctx)
+	res, err = u.featuredProgramRepo.Fetch(ctx, params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Overview:
- Add filter to search categories based on jsonsearch SQL

reference here: https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#function_json-search

@jabardigitalservice/jds-backend 

TO DO:
- Multiple category (on params)

Evidence:
project: Portal Jabar
title: add filter featured program with json search SQL
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit @satemertua

Disc on @setiadijoe : this SQL injection haven't been refactored as yesterday as you want, because we have any task remaining :seedling: 