### PR TITLE
fix meta total

### DIFF
--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -77,9 +77,7 @@ func (r *mysqlEventRepository) count(ctx context.Context, query string) (total i
 }
 
 func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request) (res []domain.Event, total int64, err error) {
-	query := querySelectAgenda
-
-	query = query + ` WHERE 1=1`
+	query := ` WHERE 1=1`
 
 	if params.Keyword != "" {
 		query = query + ` AND title like '%` + params.Keyword + `%' `
@@ -91,14 +89,14 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 
 	query = query + ` ORDER BY date, start_hour, priority DESC `
 
-	query = query + ` LIMIT ?,? `
+	query = querySelectAgenda + query + ` LIMIT ?,? `
 
 	res, err = r.fetchQuery(ctx, query, params.Offset, params.PerPage)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	total, _ = r.count(ctx, "SELECT COUNT(1) FROM events")
+	total, _ = r.count(ctx, "SELECT COUNT(1) FROM events "+query)
 
 	return
 }

--- a/core-service/src/modules/news/repository/mysql/mysql_news.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news.go
@@ -80,7 +80,7 @@ func (m *mysqlNewsRepository) count(ctx context.Context, query string) (total in
 }
 
 func (m *mysqlNewsRepository) Fetch(ctx context.Context, params *domain.Request) (res []domain.News, total int64, err error) {
-	query := querySelectNews + ` WHERE 1=1 `
+	query := ` WHERE 1=1 `
 
 	if params.Keyword != "" {
 		query = query + ` AND title like '%` + params.Keyword + `%' `
@@ -108,15 +108,15 @@ func (m *mysqlNewsRepository) Fetch(ctx context.Context, params *domain.Request)
 		query = query + ` ORDER BY created_at DESC`
 	}
 
-	query = query + ` LIMIT ?,? `
+	total, _ = m.count(ctx, ` SELECT COUNT(1) FROM news `+query)
+
+	query = querySelectNews + query + ` LIMIT ?,? `
 
 	res, err = m.fetch(ctx, query, params.Offset, params.PerPage)
 
 	if err != nil {
 		return nil, 0, err
 	}
-
-	total, _ = m.count(ctx, "SELECT COUNT(1) FROM news")
 
 	return
 }


### PR DESCRIPTION
## Changes
- fix meta: represents the amount of data after filtering

@jabardigitalservice/jds-backend 

Evidence:
project: Portal Jabar
title: fix meta: represents the amount of data after filtering
participants: @rachadiannovansyah @khihadysucahyo @firmanJS 