### PR TITLE
no longer use category as obj on events

### DIFF
--- a/core-service/src/database/migrations/1629281242_initialize_schema.up.sql
+++ b/core-service/src/database/migrations/1629281242_initialize_schema.up.sql
@@ -151,7 +151,7 @@ CREATE TABLE events (
   type ENUM('offline', 'online') NOT NULL,
   address varchar(255) DEFAULT NULL,
   url varchar(80) DEFAULT NULL,
-  category_id int(10) unsigned NOT NULL,
+  category varchar(30) NOT NULL,
   province_code varchar(191) NULL,
   city_code varchar(191) NULL,
   district_code varchar(191) NULL,
@@ -159,12 +159,11 @@ CREATE TABLE events (
   created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
-  KEY events_categories_id_fk (category_id),
-  CONSTRAINT events_categories_fk FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 CREATE INDEX idx_title ON events (title);
 CREATE INDEX idx_start_hour ON events (start_hour);
 CREATE INDEX idx_end_hour ON events (end_hour);
+CREATE INDEX idx_category ON events (category);
 
 DROP TABLE IF EXISTS feedback;
 CREATE TABLE feedback (

--- a/core-service/src/domain/event.go
+++ b/core-service/src/domain/event.go
@@ -8,18 +8,18 @@ import (
 // Event ...
 type Event struct {
 	ID           int64      `json:"id"`
-	Title        NullString `json:"title"`
-	Description  NullString `json:"description"`
-	Date         NullString `json:"date"`
-	Priority     NullString `json:"priority"`
-	StartHour    NullString `json:"start_hour,omitempty"`
-	EndHour      NullString `json:"end_hour,omitempty"`
+	Title        string     `json:"title"`
+	Description  string     `json:"description"`
+	Priority     string     `json:"priority"`
+	Date         time.Time  `json:"date"`
+	StartHour    string     `json:"start_hour"`
+	EndHour      string     `json:"end_hour"`
 	Image        NullString `json:"image"`
 	PublishedBy  NullString `json:"published_by"`
-	Type         NullString `json:"type"`
+	Type         string     `json:"type"`
 	Address      NullString `json:"address"`
 	URL          NullString `json:"url"`
-	Category     Category   `json:"category"`
+	Category     string     `json:"category"`
 	ProvinceCode Area       `json:"province_code"`
 	CityCode     Area       `json:"city_code"`
 	DistrictCode Area       `json:"district_code"`
@@ -31,22 +31,22 @@ type Event struct {
 // ListEventResponse model ..
 type ListEventResponse struct {
 	ID        int64      `json:"id"`
-	Title     NullString `json:"title" validate:"required"`
-	Date      NullString `json:"date"`
-	StartHour NullString `json:"start_hour,omitempty"`
-	EndHour   NullString `json:"end_hour,omitempty"`
-	Priority  NullString `json:"priority"`
-	Type      NullString `json:"type"`
+	Title     string     `json:"title" validate:"required"`
+	Date      time.Time  `json:"date"`
+	StartHour string     `json:"start_hour"`
+	EndHour   string     `json:"end_hour"`
+	Priority  string     `json:"priority"`
+	Type      string     `json:"type"`
 	Address   NullString `json:"address"`
 	URL       NullString `json:"url"`
-	Category  Category   `json:"category" validate:"required"`
+	Category  string     `json:"category" validate:"required"`
 }
 
 //ListEventCalendarReponse ..
 type ListEventCalendarReponse struct {
-	ID    int64      `json:"id"`
-	Title NullString `json:"title"`
-	Date  NullString `json:"date"`
+	ID    int64     `json:"id"`
+	Title string    `json:"title"`
+	Date  time.Time `json:"date"`
 }
 
 // EventUsecase ..

--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -18,7 +18,7 @@ func NewMysqlEventRepository(Conn *sql.DB) domain.EventRepository {
 	return &mysqlEventRepository{Conn}
 }
 
-var querySelectAgenda = `select id, category_id, title, priority, type, address, url, date, start_hour, end_hour, created_at, updated_at FROM events`
+var querySelectAgenda = `select id, category, title, priority, type, address, url, date, start_hour, end_hour, created_at, updated_at FROM events`
 
 func (r *mysqlEventRepository) fetchQuery(ctx context.Context, query string, args ...interface{}) (result []domain.Event, err error) {
 	rows, err := r.Conn.QueryContext(ctx, query, args...)
@@ -37,10 +37,9 @@ func (r *mysqlEventRepository) fetchQuery(ctx context.Context, query string, arg
 	result = make([]domain.Event, 0)
 	for rows.Next() {
 		event := domain.Event{}
-		categoryID := int64(0)
 		err = rows.Scan(
 			&event.ID,
-			&categoryID,
+			&event.Category,
 			&event.Title,
 			&event.Priority,
 			&event.Type,
@@ -58,7 +57,6 @@ func (r *mysqlEventRepository) fetchQuery(ctx context.Context, query string, arg
 			return nil, err
 		}
 
-		event.Category = domain.Category{ID: categoryID}
 		result = append(result, event)
 	}
 
@@ -135,7 +133,6 @@ func (r *mysqlEventRepository) fetchQueryCalendar(ctx context.Context, query str
 	result = make([]domain.Event, 0)
 	for rows.Next() {
 		event := domain.Event{}
-		categoryID := int64(0)
 		err = rows.Scan(
 			&event.ID,
 			&event.Title,
@@ -147,7 +144,6 @@ func (r *mysqlEventRepository) fetchQueryCalendar(ctx context.Context, query str
 			return nil, err
 		}
 
-		event.Category = domain.Category{ID: categoryID}
 		result = append(result, event)
 	}
 

--- a/core-service/src/modules/event/usecase/event_ucase.go
+++ b/core-service/src/modules/event/usecase/event_ucase.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 )
 
 type eventUcase struct {
@@ -24,59 +22,6 @@ func NewEventUsecase(repo domain.EventRepository, ctg domain.CategoryRepository,
 	}
 }
 
-func (u *eventUcase) fillCategoryDetails(c context.Context, data []domain.Event) ([]domain.Event, error) {
-	g, ctx := errgroup.WithContext(c)
-
-	// Get the category's id
-	mapCategories := map[int64]domain.Category{}
-
-	for _, infos := range data {
-		mapCategories[infos.Category.ID] = domain.Category{}
-	}
-
-	// Using goroutine to fetch the category's detail
-	chanCategory := make(chan domain.Category)
-	for categoryID := range mapCategories {
-		categoryID := categoryID
-		g.Go(func() error {
-			res, err := u.categories.GetByID(ctx, categoryID)
-			if err != nil {
-				return err
-			}
-			chanCategory <- res
-			return nil
-		})
-	}
-
-	go func() {
-		err := g.Wait()
-		if err != nil {
-			logrus.Error(err)
-			return
-		}
-		close(chanCategory)
-	}()
-
-	for category := range chanCategory {
-		if category != (domain.Category{}) {
-			mapCategories[category.ID] = category
-		}
-	}
-
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
-
-	// merge the category's data
-	for index, item := range data {
-		if a, ok := mapCategories[item.Category.ID]; ok {
-			data[index].Category = a
-		}
-	}
-
-	return data, nil
-}
-
 // Fetch ...
 func (u *eventUcase) Fetch(c context.Context, params *domain.Request) (res []domain.Event, total int64, err error) {
 
@@ -84,11 +29,6 @@ func (u *eventUcase) Fetch(c context.Context, params *domain.Request) (res []dom
 	defer cancel()
 
 	res, total, err = u.eventRepo.Fetch(ctx, params)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	res, err = u.fillCategoryDetails(ctx, res)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -105,12 +45,6 @@ func (u *eventUcase) GetByID(c context.Context, id int64) (res domain.Event, err
 	if err != nil {
 		return
 	}
-
-	resCategory, err := u.categories.GetByID(ctx, res.Category.ID)
-	if err != nil {
-		return domain.Event{}, err
-	}
-	res.Category = resCategory
 
 	return
 }


### PR DESCRIPTION
### Overview:
- Remove category object
- Category now only text (string)

@jabardigitalservice/jds-backend 

### Evidence:
project: Portal Jabar
title: no longer use category as obj on events
participants: @rachadiannovansyah @khihadysucahyo @sandisunandar99 

### Note:
Temporary move to draft, Will merge on Monday (req by FE)