### PR TITLE
fix meta on events

### DIFF
--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -89,14 +89,14 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 
 	query = query + ` ORDER BY date, start_hour, priority DESC `
 
+	total, _ = r.count(ctx, ` SELECT COUNT(1) FROM events `+query)
+
 	query = querySelectAgenda + query + ` LIMIT ?,? `
 
 	res, err = r.fetchQuery(ctx, query, params.Offset, params.PerPage)
 	if err != nil {
 		return nil, 0, err
 	}
-
-	total, _ = r.count(ctx, "SELECT COUNT(1) FROM events "+query)
 
 	return
 }


### PR DESCRIPTION
Overview:
- Fix meta didn't work on events

@jabardigitalservice/jds-backend 

Evidence:
project: Portal Jabar
title: Fix meta didn't work on event
participants: @rachadiannovansyah @khihadysucahyo @firmanhxc @setiadijoe @ayocodingit 