### PR TITLE
Add query block of multiple JSON Search

### DIFF
--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -78,14 +78,14 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 	query := ` WHERE 1=1`
 
 	if params.Keyword != "" {
-		query = query + ` AND title like '%` + params.Keyword + `%' `
+		query += ` AND title like '%` + params.Keyword + `%' `
 	}
 
 	if params.StartDate != "" && params.EndDate != "" {
-		query = query + ` AND date BETWEEN '` + params.StartDate + `' AND '` + params.EndDate + `'`
+		query += ` AND date BETWEEN '` + params.StartDate + `' AND '` + params.EndDate + `'`
 	}
 
-	query = query + ` ORDER BY date, start_hour, priority DESC `
+	query += ` ORDER BY date, start_hour, priority DESC `
 
 	total, _ = r.count(ctx, ` SELECT COUNT(1) FROM events `+query)
 

--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -78,7 +78,7 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 	query := ` WHERE 1=1`
 
 	if params.Keyword != "" {
-		query += ` AND title like '%` + params.Keyword + `%' `
+		query += ` AND title LIKE '%` + params.Keyword + `%' `
 	}
 
 	if params.StartDate != "" && params.EndDate != "" {
@@ -151,10 +151,10 @@ func (r *mysqlEventRepository) fetchQueryCalendar(ctx context.Context, query str
 }
 
 func (r *mysqlEventRepository) ListCalendar(ctx context.Context, params *domain.Request) (res []domain.Event, err error) {
-	query := `SELECT id, title, date from events where 1=1`
+	query := `SELECT id, title, date FROM events WHERE 1=1`
 
 	if params.StartDate != "" && params.EndDate != "" {
-		query = query + ` AND date BETWEEN '` + params.StartDate + `' and '` + params.EndDate + `'`
+		query = query + ` AND date BETWEEN '` + params.StartDate + `' AND '` + params.EndDate + `'`
 	}
 
 	query = query + ` ORDER BY date DESC `

--- a/core-service/src/modules/featured-program/repository/mysql/mysql_featured_program.go
+++ b/core-service/src/modules/featured-program/repository/mysql/mysql_featured_program.go
@@ -67,13 +67,14 @@ func (m *mysqlFeaturedProgramRepository) Fetch(ctx context.Context, params *doma
 	for idx, cat := range data {
 		if v, ok := params.Filters["categories"]; ok && v != "" {
 			if idx == 0 {
-				query = fmt.Sprintf(`%s AND JSON_SEARCH(categories, 'all', '%s') IS NOT NULL`, query, cat)
+				query = fmt.Sprintf(`%s AND (JSON_SEARCH(categories, 'all', '%s') IS NOT NULL`, query, cat)
 			} else {
 				query = fmt.Sprintf(`%s OR JSON_SEARCH(categories, 'all', '%s') IS NOT NULL`, query, cat)
 			}
 		}
 	}
-	query = query + ` LIMIT 50`
+	query += `) ` // it's imagine end blocking query of loop json_search
+	query += ` LIMIT 50`
 
 	res, err = m.fetch(ctx, query)
 

--- a/core-service/src/modules/featured-program/repository/mysql/mysql_featured_program.go
+++ b/core-service/src/modules/featured-program/repository/mysql/mysql_featured_program.go
@@ -64,16 +64,18 @@ func (m *mysqlFeaturedProgramRepository) Fetch(ctx context.Context, params *doma
 	query := `SELECT id, title, excerpt, description, organization, categories, service_type, websites, social_media, logo FROM featured_programs WHERE 1=1`
 
 	data := params.Filters["categories"].([]string)
-	for idx, cat := range data {
-		if v, ok := params.Filters["categories"]; ok && v != "" {
+
+	if len(data) > 0 {
+		for idx, cat := range data {
 			if idx == 0 {
 				query = fmt.Sprintf(`%s AND (JSON_SEARCH(categories, 'all', '%s') IS NOT NULL`, query, cat)
 			} else {
 				query = fmt.Sprintf(`%s OR JSON_SEARCH(categories, 'all', '%s') IS NOT NULL`, query, cat)
 			}
 		}
+		query += `)` // it's imagine end blocking query of loop json_search
 	}
-	query += `) ` // it's imagine end blocking query of loop json_search
+
 	query += ` LIMIT 50`
 
 	res, err = m.fetch(ctx, query)

--- a/core-service/src/modules/featured-program/repository/mysql/mysql_featured_program.go
+++ b/core-service/src/modules/featured-program/repository/mysql/mysql_featured_program.go
@@ -63,10 +63,10 @@ func (m *mysqlFeaturedProgramRepository) Fetch(ctx context.Context, params *doma
 
 	query := `SELECT id, title, excerpt, description, organization, categories, service_type, websites, social_media, logo FROM featured_programs WHERE 1=1`
 
-	data := params.Filters["categories"].([]string)
+	categories := params.Filters["categories"].([]string)
 
-	if len(data) > 0 {
-		for idx, cat := range data {
+	if len(categories) > 0 {
+		for idx, cat := range categories {
 			if idx == 0 {
 				query = fmt.Sprintf(`%s AND (JSON_SEARCH(categories, 'all', '%s') IS NOT NULL`, query, cat)
 			} else {

--- a/core-service/src/modules/information/repository/mysql/mysql_informations.go
+++ b/core-service/src/modules/information/repository/mysql/mysql_informations.go
@@ -77,7 +77,7 @@ func (mr *mysqlInformationRepository) Fetch(ctx context.Context, params *domain.
 	query := `SELECT id, category_id, title, content, slug, image, show_date, end_date, status, created_at, updated_at FROM informations`
 
 	if params.Keyword != "" {
-		query += ` WHERE title like '%` + params.Keyword + `%' `
+		query += ` WHERE title LIKE '%` + params.Keyword + `%' `
 	}
 
 	query += ` ORDER BY created_at LIMIT ?,? `

--- a/core-service/src/modules/information/repository/mysql/mysql_informations.go
+++ b/core-service/src/modules/information/repository/mysql/mysql_informations.go
@@ -77,10 +77,10 @@ func (mr *mysqlInformationRepository) Fetch(ctx context.Context, params *domain.
 	query := `SELECT id, category_id, title, content, slug, image, show_date, end_date, status, created_at, updated_at FROM informations`
 
 	if params.Keyword != "" {
-		query = query + ` WHERE title like '%` + params.Keyword + `%' `
+		query += ` WHERE title like '%` + params.Keyword + `%' `
 	}
 
-	query = query + ` ORDER BY created_at LIMIT ?,? `
+	query += ` ORDER BY created_at LIMIT ?,? `
 
 	res, err = mr.fetchQuery(ctx, query, params.Offset, params.PerPage)
 

--- a/core-service/src/modules/news/repository/mysql/mysql_news.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
 	"github.com/sirupsen/logrus"
@@ -83,7 +84,7 @@ func (m *mysqlNewsRepository) Fetch(ctx context.Context, params *domain.Request)
 	query := ` WHERE 1=1 `
 
 	if params.Keyword != "" {
-		query = query + ` AND title like '%` + params.Keyword + `%' `
+		query += ` AND title like '%` + params.Keyword + `%' `
 	}
 
 	if v, ok := params.Filters["highlight"]; ok && v != "" {
@@ -103,9 +104,9 @@ func (m *mysqlNewsRepository) Fetch(ctx context.Context, params *domain.Request)
 	}
 
 	if params.SortBy != "" {
-		query = query + ` ORDER BY ` + params.SortBy + ` ` + params.SortOrder
+		query += ` ORDER BY ` + params.SortBy + ` ` + params.SortOrder
 	} else {
-		query = query + ` ORDER BY created_at DESC`
+		query += ` ORDER BY created_at DESC`
 	}
 
 	total, _ = m.count(ctx, ` SELECT COUNT(1) FROM news `+query)

--- a/core-service/src/modules/news/repository/mysql/mysql_news.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news.go
@@ -84,7 +84,7 @@ func (m *mysqlNewsRepository) Fetch(ctx context.Context, params *domain.Request)
 	query := ` WHERE 1=1 `
 
 	if params.Keyword != "" {
-		query += ` AND title like '%` + params.Keyword + `%' `
+		query += ` AND title LIKE '%` + params.Keyword + `%' `
 	}
 
 	if v, ok := params.Filters["highlight"]; ok && v != "" {

--- a/core-service/src/modules/unit/repository/mysql/mysql_unit.go
+++ b/core-service/src/modules/unit/repository/mysql/mysql_unit.go
@@ -78,10 +78,10 @@ func (m *mysqlUnitRepository) Fetch(ctx context.Context, params *domain.Request)
 	query := querySelectUnit
 
 	if params.Keyword != "" {
-		query = query + ` WHERE name like '%` + params.Keyword + `%' `
+		query += ` WHERE name like '%` + params.Keyword + `%' `
 	}
 
-	query = query + ` ORDER BY created_at LIMIT ?,? `
+	query += ` ORDER BY created_at LIMIT ?,? `
 
 	res, err = m.fetch(ctx, query, params.Offset, params.PerPage)
 

--- a/core-service/src/modules/unit/repository/mysql/mysql_unit.go
+++ b/core-service/src/modules/unit/repository/mysql/mysql_unit.go
@@ -78,7 +78,7 @@ func (m *mysqlUnitRepository) Fetch(ctx context.Context, params *domain.Request)
 	query := querySelectUnit
 
 	if params.Keyword != "" {
-		query += ` WHERE name like '%` + params.Keyword + `%' `
+		query += ` WHERE name LIKE '%` + params.Keyword + `%' `
 	}
 
 	query += ` ORDER BY created_at LIMIT ?,? `


### PR DESCRIPTION
Overview:
- Add query blocking of json_search (with multiple choice case)
- A lit refactor silly code

@jabardigitalservice/jds-backend 

Evidence:
project: Portal Jabar
title: Add query block of multiple JSON Search
participants: @rachadiannovansyah @khihadysucahyo @firmanJS 