### PR TITLE
Search aggregation & apply post filter

### DIFF
--- a/core-service/src/domain/search.go
+++ b/core-service/src/domain/search.go
@@ -12,7 +12,7 @@ type Search struct {
 	Excerpt   string `json:"excerpt"`
 	Content   string `json:"content"`
 	Slug      string `json:"slug"`
-	Category  string `json:"category" validate:"required"`
+	Category  string `json:"category"`
 	Thumbnail string `json:"thumbnail"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
@@ -25,9 +25,9 @@ type SearchListResponse struct {
 	Title     string `json:"title"`
 	Excerpt   string `json:"excerpt"`
 	Slug      string `json:"slug"`
-	Category  string `json:"category" validate:"required"`
+	Category  string `json:"category"`
 	Thumbnail string `json:"thumbnail"`
-	CreatedAt string `json:"created_at"`
+	CreatedAt string `json:"created_at" mapstructure:"created_at"`
 }
 
 // SearchUsecase represent the search usecases

--- a/core-service/src/helpers/getters.go
+++ b/core-service/src/helpers/getters.go
@@ -69,6 +69,21 @@ func Paginate(c echo.Context, data interface{}, total int64, params domain.Reque
 	}
 }
 
+// ESAggregate ...
+func ESAggregate(aggs interface{}) *domain.MetaAggregations {
+	aggDomain := aggs.(map[string]interface{})["agg_domain"].(map[string]interface{})["buckets"].([]interface{})
+
+	return &domain.MetaAggregations{
+		Domain: domain.AggDomain{
+			News:          int64(MapValue(aggDomain, "news")),
+			Information:   int64(MapValue(aggDomain, "information")),
+			PublicService: int64(MapValue(aggDomain, "public_service")),
+			Announcement:  int64(MapValue(aggDomain, "announcement")),
+			About:         int64(MapValue(aggDomain, "about")),
+		},
+	}
+}
+
 // GetStatusCode ...
 func GetStatusCode(err error) int {
 	if err == nil {

--- a/core-service/src/helpers/mapper.go
+++ b/core-service/src/helpers/mapper.go
@@ -1,0 +1,11 @@
+package helpers
+
+func MapValue(arrMap []interface{}, key string) (value float64) {
+	for _, m := range arrMap {
+		el := m.(map[string]interface{})
+		if el["key"] == key {
+			return el["doc_count"].(float64)
+		}
+	}
+	return
+}

--- a/core-service/src/modules/search/delivery/http/search_handler.go
+++ b/core-service/src/modules/search/delivery/http/search_handler.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"fmt"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
 	"github.com/labstack/echo/v4"
@@ -25,20 +24,16 @@ func NewSearchHandler(e *echo.Group, r *echo.Group, us domain.SearchUsecase) {
 func (h *SearchHandler) FetchSearch(c echo.Context) error {
 	ctx := c.Request().Context()
 	params := helpers.GetRequestParams(c)
+	params.Filters = map[string]interface{}{
+		"domain": c.Request().URL.Query()["domain[]"],
+	}
+
 	listSearch, tot, aggs, err := h.SUsecase.Fetch(ctx, &params)
 	if err != nil {
 		return err
 	}
 	res := helpers.Paginate(c, listSearch, tot, params)
 	meta := res.Meta.(*domain.MetaData)
-
-	// FIXME: meta aggregation structure in the next PR
-	aggDomain := aggs.(map[string]interface{})["agg_domain"].(map[string]interface{})["buckets"]
-	fmt.Println("aggDomain", aggDomain)
-	meta.Aggregations = &domain.MetaAggregations{
-		Domain: domain.AggDomain{
-			News: 1, // FIXME: remove hardcoded aggregate
-		},
-	}
+	meta.Aggregations = helpers.ESAggregate(aggs)
 	return c.JSON(http.StatusOK, res)
 }


### PR DESCRIPTION
## Changes
- [fixed issue camelcase](https://github.com/mitchellh/mapstructure/pull/99): setting up a tag `mapstructure:"created_at" `
- added elastic aggregation mapvalue helper
- implement [post_filter](https://www.elastic.co/guide/en/elasticsearch/reference/2.2/search-request-post-filter.html) to apply filter, after aggregations have already been calculated

## Todo
- setup env for index name
- search sort order
- reviewing the use of [Types of multimatch query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#multi-match-types)

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: Search aggregation & apply post filter
participants: @khihadysucahyo @firmanJS @rachadiannovansyah @tukangremot 