### PR TITLE
Parse elastic date string to time format

### DIFF
--- a/core-service/src/domain/search.go
+++ b/core-service/src/domain/search.go
@@ -2,32 +2,33 @@ package domain
 
 import (
 	"context"
+	"time"
 )
 
 // Search ...
 type Search struct {
-	ID        int    `json:"id"`
-	Domain    string `json:"domain"`
-	Title     string `json:"title"`
-	Excerpt   string `json:"excerpt"`
-	Content   string `json:"content"`
-	Slug      string `json:"slug"`
-	Category  string `json:"category"`
-	Thumbnail string `json:"thumbnail"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	ID        int       `json:"id"`
+	Domain    string    `json:"domain"`
+	Title     string    `json:"title"`
+	Excerpt   string    `json:"excerpt"`
+	Content   string    `json:"content"`
+	Slug      string    `json:"slug"`
+	Category  string    `json:"category"`
+	Thumbnail string    `json:"thumbnail"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // SearchListResponse ...
 type SearchListResponse struct {
-	ID        int    `json:"id"`
-	Domain    string `json:"domain"`
-	Title     string `json:"title"`
-	Excerpt   string `json:"excerpt"`
-	Slug      string `json:"slug"`
-	Category  string `json:"category"`
-	Thumbnail string `json:"thumbnail"`
-	CreatedAt string `json:"created_at" mapstructure:"created_at"`
+	ID        int       `json:"id"`
+	Domain    string    `json:"domain"`
+	Title     string    `json:"title"`
+	Excerpt   string    `json:"excerpt"`
+	Slug      string    `json:"slug"`
+	Category  string    `json:"category"`
+	Thumbnail string    `json:"thumbnail"`
+	CreatedAt time.Time `json:"created_at" mapstructure:"created_at"`
 }
 
 // SearchUsecase represent the search usecases

--- a/core-service/src/helpers/elastic.go
+++ b/core-service/src/helpers/elastic.go
@@ -1,5 +1,13 @@
 package helpers
 
+import "time"
+
 func GetESTotalCount(mapResp map[string]interface{}) float64 {
 	return mapResp["hits"].(map[string]interface{})["total"].(interface{}).(map[string]interface{})["value"].(float64)
+}
+
+func ParseESDate(strDateTime string) time.Time {
+	tLayout := "2006-01-02 15:04:05" // timestamp layout
+	tCreatedAt, _ := time.Parse(tLayout, strDateTime)
+	return tCreatedAt
 }

--- a/core-service/src/modules/search/repository/elastic/elastic_search.go
+++ b/core-service/src/modules/search/repository/elastic/elastic_search.go
@@ -97,7 +97,7 @@ func (es *elasticSearchRepository) Fetch(ctx context.Context, params *domain.Req
 	// Pass the JSON query to the Golang client's Search() method
 	resp, err := esClient.Search(
 		esClient.Search.WithContext(ctx),
-		esClient.Search.WithIndex("ipj-content-dev"), // FIXME: this should use env
+		esClient.Search.WithIndex("ipj-content-staging"), // FIXME: this should use env
 		esClient.Search.WithBody(&query),
 		esClient.Search.WithFrom(int(params.Offset)),
 		esClient.Search.WithSize(int(params.PerPage)),

--- a/core-service/src/modules/search/repository/elastic/elastic_search.go
+++ b/core-service/src/modules/search/repository/elastic/elastic_search.go
@@ -37,11 +37,15 @@ func mapElasticDocs(mapResp map[string]interface{}) (res []domain.SearchListResp
 		doc := hit.(map[string]interface{})
 
 		// The "_source" data is another map interface nested inside of doc
-		source := doc["_source"]
+		source := doc["_source"].(map[string]interface{})
 
 		// mapstructure
 		searchData := domain.SearchListResponse{}
 		mapstructure.Decode(source, &searchData)
+
+		// parsing the date string to time.Time
+		searchData.CreatedAt = helpers.ParseESDate(source["created_at"].(string))
+
 		res = append(res, searchData)
 	}
 
@@ -93,7 +97,7 @@ func (es *elasticSearchRepository) Fetch(ctx context.Context, params *domain.Req
 	// Pass the JSON query to the Golang client's Search() method
 	resp, err := esClient.Search(
 		esClient.Search.WithContext(ctx),
-		esClient.Search.WithIndex("ipj-content-staging"), // FIXME: this should use env
+		esClient.Search.WithIndex("ipj-content-dev"), // FIXME: this should use env
 		esClient.Search.WithBody(&query),
 		esClient.Search.WithFrom(int(params.Offset)),
 		esClient.Search.WithSize(int(params.PerPage)),


### PR DESCRIPTION
## Changes
- change `createdAt` & `updatedAt` to` time.Time`
- added `ParseESDate` helper to parse elastic date string to time format

cc @jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: Parse elastic date string to time format
participants: @khihadysucahyo @rachadiannovansyah @firmanJS @tukangremot @ayocodingit 
