### PR TITLE
throw status unathorized instead of bad request if token isn't valid

### DIFF
--- a/core-service/src/middleware/jwt.go
+++ b/core-service/src/middleware/jwt.go
@@ -34,7 +34,7 @@ func (m *GoMiddleware) JWT(next echo.HandlerFunc) echo.HandlerFunc {
 			return m.JWTKey, nil
 		})
 		if err != nil {
-			if err == jwt.ErrSignatureInvalid {
+			if err == jwt.ErrSignatureInvalid || !tkn.Valid {
 				return echo.NewHTTPError(http.StatusUnauthorized, err.Error())
 			}
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())


### PR DESCRIPTION
## Changes
- throw status unathorized instead of bad request if token isn't valid

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: handle throw status unathorized instead of bad request if token isn't valid
participants: @khihadysucahyo @rachadiannovansyah @ayocodingit @bangunbagustapa 
