### PR TITLE
fill data tags on usecase agenda

### DIFF
--- a/core-service/src/domain/event.go
+++ b/core-service/src/domain/event.go
@@ -21,6 +21,7 @@ type Event struct {
 	Address      NullString `json:"address"`
 	URL          NullString `json:"url"`
 	Category     string     `json:"category"`
+	Tags         []DataTag  `json:"tags"`
 	ProvinceCode Area       `json:"province_code"`
 	CityCode     Area       `json:"city_code"`
 	DistrictCode Area       `json:"district_code"`
@@ -69,6 +70,7 @@ type ListEventResponse struct {
 	Address   NullString `json:"address"`
 	URL       NullString `json:"url"`
 	Category  string     `json:"category" validate:"required"`
+	Tags      []DataTag  `json:"tags"`
 }
 
 //ListEventCalendarReponse ..


### PR DESCRIPTION
Overview:
- fill data tags on the event use case to show the current tag on each agenda

cc: @jabardigitalservice/jds-backend 

Evidence:
project: Portal Jabar
title: fill data tags on usecase agenda
participants: @rachadiannovansyah @khihadysucahyo @sandisunandar99 @ayocodingit 