### PR TITLE
news status update feature

### DIFF
--- a/core-service/src/domain/news.go
+++ b/core-service/src/domain/news.go
@@ -51,6 +51,11 @@ type StoreNewsRequest struct {
 	UpdatedBy User     `json:"created_by"`
 }
 
+// UpdateNewsStatusRequest ...
+type UpdateNewsStatusRequest struct {
+	Status string `json:"status"`
+}
+
 // NewsListResponse ...
 type NewsListResponse struct {
 	ID        int64      `json:"id"`
@@ -113,6 +118,7 @@ type NewsUsecase interface {
 	AddShare(ctx context.Context, id int64) error
 	Store(context.Context, *StoreNewsRequest) error
 	Update(context.Context, int64, *StoreNewsRequest) error
+	UpdateStatus(context.Context, int64, string) error
 }
 
 // NewsRepository represent the news repository contract
@@ -126,4 +132,5 @@ type NewsRepository interface {
 	AddShare(ctx context.Context, id int64) (err error)
 	Store(ctx context.Context, n *StoreNewsRequest) error
 	Update(ctx context.Context, id int64, n *StoreNewsRequest) error
+	UpdateStatus(ctx context.Context, id int64, stat string) error
 }

--- a/core-service/src/domain/news.go
+++ b/core-service/src/domain/news.go
@@ -53,7 +53,7 @@ type StoreNewsRequest struct {
 
 // UpdateNewsStatusRequest ...
 type UpdateNewsStatusRequest struct {
-	Status string `json:"status"`
+	Status string `json:"status" validate:"required,alpha,eq=DRAFT|eq=REVIEW|eq=PUBLISHED|eq=ARCHIVED"`
 }
 
 // NewsListResponse ...

--- a/core-service/src/modules/news/delivery/http/news_handler.go
+++ b/core-service/src/modules/news/delivery/http/news_handler.go
@@ -249,6 +249,10 @@ func (h *NewsHandler) UpdateStatus(c echo.Context) (err error) {
 		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
 	}
 
+	if err = validator.New().Struct(n); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
 	reqID, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return c.JSON(http.StatusNotFound, domain.ErrNotFound.Error())

--- a/core-service/src/modules/news/delivery/http/news_handler.go
+++ b/core-service/src/modules/news/delivery/http/news_handler.go
@@ -1,10 +1,11 @@
 package http
 
 import (
-	"github.com/mitchellh/mapstructure"
-	"gopkg.in/go-playground/validator.v9"
 	"net/http"
 	"strconv"
+
+	"github.com/mitchellh/mapstructure"
+	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/jinzhu/copier"
 	"github.com/labstack/echo/v4"
@@ -36,6 +37,7 @@ func NewNewsHandler(e *echo.Group, r *echo.Group, us domain.NewsUsecase) {
 	r.POST("/news", handler.Store)
 	e.GET("/news/:id", handler.GetByID)
 	r.PUT("/news/:id", handler.Update)
+	r.PATCH("/news/:id/status", handler.UpdateStatus)
 	e.GET("/news/slug/:slug", handler.GetBySlug)
 	e.GET("/news/banner", handler.FetchNewsBanner)
 	e.GET("/news/headline", handler.FetchNewsHeadline)
@@ -238,4 +240,27 @@ func (h *NewsHandler) Update(c echo.Context) (err error) {
 	copier.Copy(&res, &n)
 
 	return c.JSON(http.StatusOK, res)
+}
+
+// UpdateStatus will update the news status by given request body
+func (h *NewsHandler) UpdateStatus(c echo.Context) (err error) {
+	n := new(domain.UpdateNewsStatusRequest)
+	if err = c.Bind(n); err != nil {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
+	}
+
+	reqID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return c.JSON(http.StatusNotFound, domain.ErrNotFound.Error())
+	}
+
+	ctx := c.Request().Context()
+	err = h.CUsecase.UpdateStatus(ctx, int64(reqID), n.Status)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"message": "successfully update status",
+	})
 }

--- a/core-service/src/modules/news/repository/mysql/mysql_news.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news.go
@@ -268,3 +268,18 @@ func (m *mysqlNewsRepository) Update(ctx context.Context, id int64, n *domain.St
 
 	return
 }
+
+func (m *mysqlNewsRepository) UpdateStatus(ctx context.Context, id int64, status string) (err error) {
+	query := `UPDATE news SET status=? WHERE id=?`
+	stmt, err := m.Conn.PrepareContext(ctx, query)
+	if err != nil {
+		return
+	}
+
+	_, err = stmt.ExecContext(ctx, status, id)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -3,8 +3,9 @@ package usecase
 import (
 	"context"
 	"fmt"
-	"github.com/gosimple/slug"
 	"time"
+
+	"github.com/gosimple/slug"
 
 	"github.com/jinzhu/copier"
 
@@ -414,4 +415,11 @@ func (n *newsUsecase) Update(c context.Context, id int64, dt *domain.StoreNewsRe
 	}
 
 	return
+}
+
+func (n *newsUsecase) UpdateStatus(c context.Context, id int64, status string) (err error) {
+	ctx, cancel := context.WithTimeout(c, n.contextTimeout)
+	defer cancel()
+
+	return n.newsRepo.UpdateStatus(ctx, id, status)
 }


### PR DESCRIPTION
## Changes
- added update status usecase
- manually enum status validator (still lookin best practice for this case #todo)

@jabardigitalservice/jds-backend 

## Todo
- setup cron to archiving news basen on start/publish date and duration
- policy to update status

## Evidence
project: Portal Jabar
title: added news status update feature
participants: @khihadysucahyo @rachadiannovansyah @ayocodingit 