### PR TITLE
Give default limit for tags suggestion

### DIFF
--- a/core-service/src/modules/tag/delivery/http/tag_handler.go
+++ b/core-service/src/modules/tag/delivery/http/tag_handler.go
@@ -29,6 +29,11 @@ func (h *TagHandler) FetchTag(c echo.Context) error {
 
 	params := helpers.GetRequestParams(c)
 
+	// throw if keyword is empty and saving our repo!
+	if len(params.Keyword) == 0 {
+		return c.JSON(http.StatusOK, []string{})
+	}
+
 	listTags, _, err := h.TagUsecase.FetchTag(ctx, &params)
 
 	if err != nil {

--- a/core-service/src/modules/tag/repository/mysql/mysql_tag.go
+++ b/core-service/src/modules/tag/repository/mysql/mysql_tag.go
@@ -71,6 +71,8 @@ func (m *mysqlTagRepository) FetchTag(ctx context.Context, params *domain.Reques
 		query += ` WHERE name LIKE '%` + params.Keyword + `%' `
 	}
 
+	query += ` LIMIT 5`
+
 	res, err = m.fetch(ctx, query)
 
 	if err != nil {


### PR DESCRIPTION
Overview:
- Add limit default for tags suggestion (reason -> references: tags medium)
- Throw if no longer keyword provided (for saving repo with not hit them)

cc: @jabardigitalservice/jds-backend 

Evidence:
project: Portal Jabar
title: Menambahkan empty state + limit tags
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 