### PR TITLE
Add obj user when store & remove field description on agenda

### DIFF
--- a/core-service/src/database/migrations/1629281242_initialize_schema.up.sql
+++ b/core-service/src/database/migrations/1629281242_initialize_schema.up.sql
@@ -142,7 +142,6 @@ DROP TABLE IF EXISTS events;
 CREATE TABLE events (
   id int(10) unsigned NOT NULL AUTO_INCREMENT,
   title varchar(80) NOT NULL,
-  description varchar(255),
   date date NOT NULL,
   priority tinyint(1) DEFAULT 1 NOT NULL,
   start_hour time NOT NULL,

--- a/core-service/src/domain/event.go
+++ b/core-service/src/domain/event.go
@@ -9,7 +9,6 @@ import (
 type Event struct {
 	ID           int64      `json:"id"`
 	Title        string     `json:"title"`
-	Description  string     `json:"description"`
 	Priority     string     `json:"priority"`
 	Date         time.Time  `json:"date"`
 	StartHour    string     `json:"start_hour"`
@@ -76,21 +75,20 @@ type ListEventResponse struct {
 }
 
 type DetailEventResponse struct {
-	ID          int64      `json:"id"`
-	Title       string     `json:"title"`
-	Description string     `json:"description"`
-	Date        time.Time  `json:"date"`
-	StartHour   string     `json:"start_hour"`
-	EndHour     string     `json:"end_hour"`
-	Type        string     `json:"type"`
-	Status      string     `json:"status"`
-	Address     NullString `json:"address"`
-	URL         NullString `json:"url"`
-	Category    string     `json:"category"`
-	Tags        []DataTag  `json:"tags"`
-	CreatedBy   Author     `json:"created_by"`
-	CreatedAt   time.Time  `json:"created_at"`
-	UpdatedAt   time.Time  `json:"updated_at"`
+	ID        int64      `json:"id"`
+	Title     string     `json:"title"`
+	Date      time.Time  `json:"date"`
+	StartHour string     `json:"start_hour"`
+	EndHour   string     `json:"end_hour"`
+	Type      string     `json:"type"`
+	Status    string     `json:"status"`
+	Address   NullString `json:"address"`
+	URL       NullString `json:"url"`
+	Category  string     `json:"category"`
+	Tags      []DataTag  `json:"tags"`
+	CreatedBy Author     `json:"created_by"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
 }
 
 //ListEventCalendarReponse ..

--- a/core-service/src/domain/event.go
+++ b/core-service/src/domain/event.go
@@ -41,6 +41,7 @@ type StoreRequestEvent struct {
 	EndHour   string   `json:"end_hour" validate:"required"`
 	Category  string   `json:"category" validate:"required"`
 	Tags      []string `json:"tags"`
+	CreatedBy User     `json:"created_by" validate:"required"`
 }
 
 // UpdateRequestEvent ..

--- a/core-service/src/modules/event/delivery/http/event_handler.go
+++ b/core-service/src/modules/event/delivery/http/event_handler.go
@@ -114,13 +114,16 @@ func (h *EventHandler) Store(c echo.Context) (err error) {
 		return c.JSON(http.StatusUnprocessableEntity, err.Error())
 	}
 
-	auth := domain.JwtCustomClaims{}
-	mapstructure.Decode(c.Get("auth:user"), &auth)
-
 	var ok bool
 	if ok, err = isRequestValid(&events); !ok {
 		return c.JSON(http.StatusBadRequest, err.Error())
 	}
+
+	auth := domain.JwtCustomClaims{}
+	mapstructure.Decode(c.Get("auth:user"), &auth)
+
+	events.CreatedBy.ID = auth.ID
+	events.CreatedBy.Name = auth.Name
 
 	ctx := c.Request().Context()
 	err = h.EventUcase.Store(ctx, &events)

--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -198,13 +198,23 @@ func (r *mysqlEventRepository) GetByTitle(ctx context.Context, title string) (re
 }
 
 func (r *mysqlEventRepository) Store(ctx context.Context, m *domain.StoreRequestEvent) (err error) {
-	query := `INSERT events SET title=? , type=? , url=? , address=? , date=? , start_hour=? , end_hour=? , category=?`
+	query := `INSERT events SET title=? , type=? , url=? , address=? , date=? , start_hour=? , end_hour=? , category=? , created_by=?`
 	stmt, err := r.Conn.PrepareContext(ctx, query)
 	if err != nil {
 		return
 	}
 
-	res, err := stmt.ExecContext(ctx, m.Title, m.Type, m.URL, m.Address, m.Date, m.StartHour, m.EndHour, m.Category)
+	res, err := stmt.ExecContext(ctx,
+		m.Title,
+		m.Type,
+		m.URL,
+		m.Address,
+		m.Date,
+		m.StartHour,
+		m.EndHour,
+		m.Category,
+		m.CreatedBy.ID.String(),
+	)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Overview:
- No longer need "description"
- Add user data on every store events

Evidence:
project: Portal Jabar
title: Menambahkan object user pada event & menghilangkan field description
participants: @rachadiannovansyah @khihadysucahyo 