### PR TITLE
Add timestamps on store news & store event

### DIFF
--- a/core-service/src/domain/event.go
+++ b/core-service/src/domain/event.go
@@ -31,17 +31,19 @@ type Event struct {
 
 // StoreRequestEvent ..
 type StoreRequestEvent struct {
-	ID        int64    `json:"id"`
-	Title     string   `json:"title" validate:"required"`
-	Type      string   `json:"type" validate:"required"`
-	URL       string   `json:"url"`
-	Address   string   `json:"address"`
-	Date      string   `json:"date" validate:"required"`
-	StartHour string   `json:"start_hour" validate:"required"`
-	EndHour   string   `json:"end_hour" validate:"required"`
-	Category  string   `json:"category" validate:"required"`
-	Tags      []string `json:"tags"`
-	CreatedBy User     `json:"created_by" validate:"required"`
+	ID        int64     `json:"id"`
+	Title     string    `json:"title" validate:"required"`
+	Type      string    `json:"type" validate:"required"`
+	URL       string    `json:"url"`
+	Address   string    `json:"address"`
+	Date      string    `json:"date" validate:"required"`
+	StartHour string    `json:"start_hour" validate:"required"`
+	EndHour   string    `json:"end_hour" validate:"required"`
+	Category  string    `json:"category" validate:"required"`
+	Tags      []string  `json:"tags"`
+	CreatedBy User      `json:"created_by" validate:"required"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // UpdateRequestEvent ..

--- a/core-service/src/domain/news.go
+++ b/core-service/src/domain/news.go
@@ -34,25 +34,27 @@ type News struct {
 }
 
 type StoreNewsRequest struct {
-	ID        int64    `json:"id"`
-	Title     string   `json:"title" validate:"required"`
-	Excerpt   string   `json:"excerpt"`
-	Content   string   `json:"content"`
-	Slug      string   `json:"slug"`
-	Image     string   `json:"image"`
-	Video     string   `json:"video"`
-	Source    string   `json:"source"`
-	Status    string   `json:"status"`
-	Type      string   `json:"type"`
-	Category  string   `json:"category"`
-	Author    User     `json:"author"`
-	StartDate string   `json:"start_date"`
-	EndDate   string   `json:"end_date"`
-	Tags      []string `json:"tags"`
-	AreaID    int64    `json:"area_id"`
-	IsLive    int8     `json:"is_live"`
-	CreatedBy User     `json:"created_by"`
-	UpdatedBy User     `json:"created_by"`
+	ID        int64     `json:"id"`
+	Title     string    `json:"title" validate:"required"`
+	Excerpt   string    `json:"excerpt"`
+	Content   string    `json:"content"`
+	Slug      string    `json:"slug"`
+	Image     string    `json:"image"`
+	Video     string    `json:"video"`
+	Source    string    `json:"source"`
+	Status    string    `json:"status"`
+	Type      string    `json:"type"`
+	Category  string    `json:"category"`
+	Author    User      `json:"author"`
+	StartDate string    `json:"start_date"`
+	EndDate   string    `json:"end_date"`
+	Tags      []string  `json:"tags"`
+	AreaID    int64     `json:"area_id"`
+	IsLive    int8      `json:"is_live"`
+	CreatedBy User      `json:"created_by"`
+	UpdatedBy User      `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // UpdateNewsStatusRequest ...

--- a/core-service/src/modules/event/usecase/event_ucase.go
+++ b/core-service/src/modules/event/usecase/event_ucase.go
@@ -193,6 +193,8 @@ func (u *eventUcase) Store(c context.Context, m *domain.StoreRequestEvent) (err 
 	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
 	defer cancel()
 
+	m.CreatedAt = time.Now()
+	m.UpdatedAt = time.Now()
 	err = u.eventRepo.Store(ctx, m)
 	if err != nil {
 		return

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -405,6 +405,8 @@ func (n *newsUsecase) Store(c context.Context, dt *domain.StoreNewsRequest) (err
 	defer cancel()
 
 	dt.Slug = fmt.Sprintf("%s-%s", slug.Make(dt.Title), uuid.New().String())
+	dt.CreatedAt = time.Now()
+	dt.UpdatedAt = time.Now()
 	err = n.newsRepo.Store(ctx, dt)
 
 	if err = n.storeTags(ctx, dt.ID, dt.Tags); err != nil {


### PR DESCRIPTION
Overview:
- Add timestamps res on store news
- Add timestamps res on store event

cc: @jabardigitalservice/jds-backend 

Evidence:
project: Portal Jabar
title: Fix timestamps on store news & agenda
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 