### PR TITLE
make slug on published

### DIFF
--- a/core-service/src/helpers/converter.go
+++ b/core-service/src/helpers/converter.go
@@ -1,5 +1,7 @@
 package helpers
 
+import "time"
+
 // SetPointerString ...
 func SetPointerString(val string) *string {
 	if val == "" {
@@ -14,4 +16,9 @@ func SetPointerInt64(val int64) *int64 {
 		return nil
 	}
 	return &val
+}
+
+// ConvertTimeToString ...
+func ConvertTimeToString(t time.Time) string {
+	return t.Format("2006-01-02")
 }

--- a/core-service/src/modules/news/repository/mysql/mysql_news.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news.go
@@ -20,7 +20,7 @@ func NewMysqlNewsRepository(Conn *sql.DB) domain.NewsRepository {
 	return &mysqlNewsRepository{Conn}
 }
 
-var querySelectNews = `SELECT id, category, title, excerpt, content, image, video, slug, author_id, type, views, shared, source, status, created_at, updated_at FROM news`
+var querySelectNews = `SELECT id, category, title, excerpt, content, image, video, slug, author_id, type, views, shared, source, start_date, end_date, status, created_at, updated_at FROM news`
 
 func (m *mysqlNewsRepository) fetch(ctx context.Context, query string, args ...interface{}) (result []domain.News, err error) {
 	rows, err := m.Conn.QueryContext(ctx, query, args...)
@@ -54,6 +54,8 @@ func (m *mysqlNewsRepository) fetch(ctx context.Context, query string, args ...i
 			&t.Views,
 			&t.Shared,
 			&t.Source,
+			&t.StartDate,
+			&t.EndDate,
 			&t.Status,
 			&t.CreatedAt,
 			&t.UpdatedAt,
@@ -298,7 +300,7 @@ func (m *mysqlNewsRepository) Store(ctx context.Context, n *domain.StoreNewsRequ
 }
 
 func (m *mysqlNewsRepository) Update(ctx context.Context, id int64, n *domain.StoreNewsRequest) (err error) {
-	query := `UPDATE news SET title=?, excerpt=?, content=?, image=?, category=?,
+	query := `UPDATE news SET title=?, excerpt=?, content=?, image=?, category=?, slug=?,
 		source=?, status=?, type=?, start_date=?, end_date=?, area_id=?, updated_by=?, updated_at=? WHERE id=?`
 	stmt, err := m.Conn.PrepareContext(ctx, query)
 	if err != nil {
@@ -311,6 +313,7 @@ func (m *mysqlNewsRepository) Update(ctx context.Context, id int64, n *domain.St
 		n.Content,
 		n.Image,
 		n.Category,
+		n.Slug,
 		n.Source,
 		n.Status,
 		"article",

--- a/core-service/src/modules/news/repository/mysql/mysql_news_test.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news_test.go
@@ -26,6 +26,8 @@ func TestFetch(t *testing.T) {
 			Views:     10,
 			Shared:    25,
 			Image:     domain.NullString{String: "image", Valid: true},
+			StartDate: time.Now(),
+			EndDate:   time.Now(),
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 		},
@@ -37,18 +39,20 @@ func TestFetch(t *testing.T) {
 			Views:     15,
 			Shared:    30,
 			Image:     domain.NullString{String: "image 2", Valid: true},
+			StartDate: time.Now(),
+			EndDate:   time.Now(),
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 		},
 	}
 
-	rows := sqlmock.NewRows([]string{"id", "category", "title", "excerpt", "content", "image", "video", "slug", "author_id", "type", "views", "shared", "source", "status", "created_at", "updated_at"}).
+	rows := sqlmock.NewRows([]string{"id", "category", "title", "excerpt", "content", "image", "video", "slug", "author_id", "type", "views", "shared", "source", "start_date", "end_date", "status", "created_at", "updated_at"}).
 		AddRow(mockNews[0].ID, mockNews[0].Category, mockNews[0].Title, mockNews[0].Excerpt, mockNews[0].Content,
-			nil, nil, mockNews[0].Slug, "", "", mockNews[0].Views, mockNews[0].Shared, mockNews[0].Source.String, mockNews[0].Status, mockNews[0].CreatedAt, mockNews[0].UpdatedAt).
+			nil, nil, mockNews[0].Slug, "", "", mockNews[0].Views, mockNews[0].Shared, mockNews[0].Source.String, mockNews[0].StartDate, mockNews[0].EndDate, mockNews[0].Status, mockNews[0].CreatedAt, mockNews[0].UpdatedAt).
 		AddRow(mockNews[1].ID, mockNews[1].Category, mockNews[1].Title, mockNews[1].Excerpt, mockNews[1].Content,
-			nil, nil, mockNews[1].Slug, "", "", mockNews[1].Views, mockNews[1].Shared, mockNews[1].Source.String, mockNews[1].Status, mockNews[1].CreatedAt, mockNews[1].UpdatedAt)
+			nil, nil, mockNews[1].Slug, "", "", mockNews[1].Views, mockNews[1].Shared, mockNews[1].Source.String, mockNews[1].StartDate, mockNews[1].EndDate, mockNews[1].Status, mockNews[1].CreatedAt, mockNews[1].UpdatedAt)
 
-	query := "SELECT id, category, title, excerpt, content, image, video, slug, author_id, type, views, shared, source, status, created_at, updated_at FROM news"
+	query := "SELECT id, category, title, excerpt, content, image, video, slug, author_id, type, views, shared, source, start_date, end_date, status, created_at, updated_at FROM news"
 
 	mock.ExpectQuery(query).WillReturnRows(rows)
 	a := mysqlRepo.NewMysqlNewsRepository(db)


### PR DESCRIPTION
## Changes
- make slug func
- only generate slug when status published
- added helper `ConvertTimeToString`
- adjust select props on news lists test by adding `startDate` and `endDate`
- converting binding startDate and endDate to string before use an existing updateReposiory, (updateRequest struct receive a string)

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: make slug on published
participants: @khihadysucahyo @rachadiannovansyah @ayocodingit @rindibudiaramdhan 