### PR TITLE
Prevent to add same tags if exists

### DIFF
--- a/core-service/src/domain/tag.go
+++ b/core-service/src/domain/tag.go
@@ -17,4 +17,5 @@ type TagUsecase interface {
 type TagRepository interface {
 	StoreTag(ctx context.Context, t *Tag) error
 	FetchTag(ctx context.Context, param *Request) ([]Tag, int64, error)
+	GetTagByName(ctx context.Context, name string) (Tag, error)
 }

--- a/core-service/src/modules/event/usecase/event_ucase.go
+++ b/core-service/src/modules/event/usecase/event_ucase.go
@@ -202,9 +202,16 @@ func (u *eventUcase) Store(c context.Context, m *domain.StoreRequestEvent) (err 
 		tag := &domain.Tag{
 			Name: tagName,
 		}
-		err = u.tagsRepo.StoreTag(ctx, tag)
-		if err != nil {
-			return
+
+		// check tags already exists
+		var checkTag domain.Tag
+		checkTag, err = u.tagsRepo.GetTagByName(ctx, tagName)
+
+		if checkTag.Name == "" {
+			err = u.tagsRepo.StoreTag(ctx, tag)
+			if err != nil {
+				return
+			}
 		}
 
 		dataTag := &domain.DataTag{

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -281,9 +281,16 @@ func (n *newsUsecase) storeTags(ctx context.Context, newsId int64, tags []string
 		tag := &domain.Tag{
 			Name: tagName,
 		}
-		err = n.tagRepo.StoreTag(ctx, tag)
-		if err != nil {
-			return
+
+		// check tags already exists
+		var checkTag domain.Tag
+		checkTag, _ = n.tagRepo.GetTagByName(ctx, tagName)
+
+		if checkTag.Name == "" {
+			err = n.tagRepo.StoreTag(ctx, tag)
+			if err != nil {
+				return
+			}
 		}
 
 		dataTag := &domain.DataTag{

--- a/core-service/src/modules/tag/repository/mysql/mysql_tag.go
+++ b/core-service/src/modules/tag/repository/mysql/mysql_tag.go
@@ -105,3 +105,20 @@ func (m *mysqlTagRepository) StoreTag(ctx context.Context, t *domain.Tag) (err e
 
 	return
 }
+
+func (m *mysqlTagRepository) GetTagByName(ctx context.Context, name string) (res domain.Tag, err error) {
+	query := querySelectTags + ` WHERE name = ?`
+
+	list, err := m.fetch(ctx, query, name)
+	if err != nil {
+		return
+	}
+
+	if len(list) > 0 {
+		res = list[0]
+	} else {
+		return res, domain.ErrNotFound
+	}
+
+	return
+}


### PR DESCRIPTION
Overview:
- Prevent to add same tags if exists

cc: @jabardigitalservice/jds-backend 

Evidence:
project: Portal Jabar
title: Menambahkan kondisi pada penyimpanan tags domain
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit @sandisunandar99 