### PR TITLE
set temporary and unique slug based on news id

### DIFF
--- a/core-service/src/helpers/converter.go
+++ b/core-service/src/helpers/converter.go
@@ -1,6 +1,11 @@
 package helpers
 
-import "time"
+import (
+	"fmt"
+	"time"
+
+	"github.com/gosimple/slug"
+)
 
 // SetPointerString ...
 func SetPointerString(val string) *string {
@@ -21,4 +26,13 @@ func SetPointerInt64(val int64) *int64 {
 // ConvertTimeToString ...
 func ConvertTimeToString(t time.Time) string {
 	return t.Format("2006-01-02")
+}
+
+// MakeSlug ...
+func MakeSlug(title string, newsID int64) string {
+	// max slug length is 100 characters: 90 for title + 10 for newsID
+	if len(title) > 90 {
+		title = title[:90]
+	}
+	return fmt.Sprintf("%v-%v", slug.Make(title), newsID)
 }

--- a/core-service/src/modules/news/repository/mysql/mysql_news.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
 	"github.com/sirupsen/logrus"
 )
 
@@ -273,11 +274,14 @@ func (m *mysqlNewsRepository) Store(ctx context.Context, n *domain.StoreNewsRequ
 		endDate = &n.EndDate
 	}
 
+	// temporary unique slug
+	slug := helpers.MakeSlug(n.Title, time.Now().Unix())
+
 	res, err := stmt.ExecContext(ctx,
 		n.Title,
 		n.Excerpt,
 		n.Content,
-		n.Slug,
+		slug,
 		n.Image,
 		n.Category,
 		n.Source,


### PR DESCRIPTION
## Changes
- added MakeSlug Helper
- set temporary and unique slug before create based on `(title-unix())`
- update unique slug based on `(title-newsID)` on published
