### PR TITLE
Multiple filter params category event

### DIFF
--- a/core-service/src/database/migrations/20220217073352_add_column_published_at_on_news_table.up.sql
+++ b/core-service/src/database/migrations/20220217073352_add_column_published_at_on_news_table.up.sql
@@ -1,5 +1,2 @@
-BEGIN;
-ALTER TABLE news
-ADD published_at timestamp AFTER `updated_by`;
+ALTER TABLE news ADD published_at timestamp AFTER `updated_by`;
 CREATE INDEX news_published_at_index ON news (published_at);
-COMMIT;

--- a/core-service/src/database/migrations/20220304034055_add_column_created_by_on_events_table.down.sql
+++ b/core-service/src/database/migrations/20220304034055_add_column_created_by_on_events_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events DROP COLUMN created_by;

--- a/core-service/src/database/migrations/20220304034055_add_column_created_by_on_events_table.up.sql
+++ b/core-service/src/database/migrations/20220304034055_add_column_created_by_on_events_table.up.sql
@@ -1,0 +1,4 @@
+BEGIN;
+ALTER TABLE events
+ADD created_by varchar(36) AFTER `deleted_at`;
+COMMIT;

--- a/core-service/src/database/migrations/20220304034055_add_column_created_by_on_events_table.up.sql
+++ b/core-service/src/database/migrations/20220304034055_add_column_created_by_on_events_table.up.sql
@@ -1,4 +1,1 @@
-BEGIN;
-ALTER TABLE events
-ADD created_by varchar(36) AFTER `deleted_at`;
-COMMIT;
+ALTER TABLE events ADD created_by varchar(36) AFTER `deleted_at`;

--- a/core-service/src/helpers/converter.go
+++ b/core-service/src/helpers/converter.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gosimple/slug"
@@ -46,4 +47,9 @@ func MakeSlug(title string, newsID int64) string {
 		title = title[:90]
 	}
 	return fmt.Sprintf("%v-%v", slug.Make(title), newsID)
+}
+
+// ConvertSliceToString ...
+func ConverSliceToString(slice []string, delimiter string) string {
+	return strings.Join(slice, delimiter)
 }

--- a/core-service/src/modules/event/delivery/http/event_handler.go
+++ b/core-service/src/modules/event/delivery/http/event_handler.go
@@ -50,8 +50,8 @@ func (h *EventHandler) Fetch(c echo.Context) error {
 
 	params := helpers.GetRequestParams(c)
 	params.Filters = map[string]interface{}{
-		"type":     c.QueryParam("type"),
-		"category": c.QueryParam("cat"),
+		"type":       c.QueryParam("type"),
+		"categories": c.Request().URL.Query()["cat[]"],
 	}
 
 	listEvent, total, err := h.EventUcase.Fetch(ctx, &params)

--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -124,12 +125,17 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 		query = fmt.Sprintf(`%s AND type = "%s"`, query, v)
 	}
 
-	if v, ok := params.Filters["category"]; ok && v != "" {
-		query = fmt.Sprintf(`%s AND category = '%s'`, query, v)
-	}
-
 	if params.StartDate != "" && params.EndDate != "" {
 		query += ` AND date BETWEEN '` + params.StartDate + `' AND '` + params.EndDate + `'`
+	}
+
+	if v, ok := params.Filters["categories"]; ok && v != "" {
+		// casting params for strings.Join to avoiding casting an interface type
+		castingParams := v.([]string)
+
+		// string.Join to concates element of strings
+		joinParams := strings.Join(castingParams, ", ")
+		query = fmt.Sprintf(`%s AND category IN (%s)`, query, joinParams)
 	}
 
 	if params.SortBy != "" {

--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -131,8 +131,8 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 
 	categories := params.Filters["categories"].([]string)
 	if len(categories) > 0 {
-		joinParams := strings.Join(categories, ", ")
-		query = fmt.Sprintf(`%s AND category IN (%s)`, query, joinParams)
+		joinParams := strings.Join(categories, "','")
+		query = fmt.Sprintf(`%s AND category IN ('%s')`, query, joinParams)
 	}
 
 	if params.SortBy != "" {

--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
 	"github.com/sirupsen/logrus"
 )
 
@@ -131,8 +131,7 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 
 	categories := params.Filters["categories"].([]string)
 	if len(categories) > 0 {
-		joinParams := strings.Join(categories, "','")
-		query = fmt.Sprintf(`%s AND category IN ('%s')`, query, joinParams)
+		query = fmt.Sprintf(`%s AND category IN ('%s')`, query, helpers.ConverSliceToString(categories, "','"))
 	}
 
 	if params.SortBy != "" {

--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -138,7 +138,7 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 		query += ` ORDER BY date DESC `
 	}
 
-	total, _ = r.count(ctx, ` SELECT COUNT(1) FROM events WHERE deleted_at is NULL `)
+	total, _ = r.count(ctx, ` SELECT COUNT(1) FROM events WHERE deleted_at is NULL `+query)
 
 	query = querySelectAgenda + query + ` LIMIT ?,? `
 

--- a/core-service/src/modules/event/repository/mysql/mysql_event.go
+++ b/core-service/src/modules/event/repository/mysql/mysql_event.go
@@ -129,12 +129,9 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 		query += ` AND date BETWEEN '` + params.StartDate + `' AND '` + params.EndDate + `'`
 	}
 
-	if v, ok := params.Filters["categories"]; ok && v != "" {
-		// casting params for strings.Join to avoiding casting an interface type
-		castingParams := v.([]string)
-
-		// string.Join to concates element of strings
-		joinParams := strings.Join(castingParams, ", ")
+	categories := params.Filters["categories"].([]string)
+	if len(categories) > 0 {
+		joinParams := strings.Join(categories, ", ")
 		query = fmt.Sprintf(`%s AND category IN (%s)`, query, joinParams)
 	}
 
@@ -146,7 +143,7 @@ func (r *mysqlEventRepository) Fetch(ctx context.Context, params *domain.Request
 
 	total, _ = r.count(ctx, ` SELECT COUNT(1) FROM events WHERE deleted_at is NULL `+query)
 
-	query = querySelectAgenda + query + ` LIMIT ?,? `
+	query = querySelectAgenda + query + `LIMIT ?,? `
 
 	res, err = r.fetchQuery(ctx, query, params.Offset, params.PerPage)
 	if err != nil {


### PR DESCRIPTION
Overview:
- add helper to convert slice to string
- modify endpoint filter to received multiple params value categories
- also add schema migration `created_by`

cc: @jabardigitalservice/jds-backend 

Evidence:
project: Portal Jabar
title: Multiple filter params category event
participants: @rachadiannovansyah @khihadysucahyo @rizkyrmsyah @sandisunandar99 @ayocodingit 