### PR TITLE
use pointer of instead of sql.Nulltime

### DIFF
--- a/core-service/src/domain/data_tag.go
+++ b/core-service/src/domain/data_tag.go
@@ -15,5 +15,5 @@ type DataTag struct {
 type DataTagRepository interface {
 	FetchDataTags(ctx context.Context, id int64) ([]DataTag, error)
 	StoreDataTag(ctx context.Context, dt *DataTag) error
-	DeleteDataTag(ctx context.Context, id int64) error
+	DeleteDataTag(ctx context.Context, id int64, domain string) error
 }

--- a/core-service/src/domain/news.go
+++ b/core-service/src/domain/news.go
@@ -30,35 +30,35 @@ type News struct {
 	IsLive      int8       `json:"is_live"`
 	CreatedBy   User       `json:"created_by"`
 	UpdatedBy   User       `json:"updated_by"`
-	PublishedAt NullTime   `json:"published_at"`
+	PublishedAt *time.Time `json:"published_at"`
 	CreatedAt   time.Time  `json:"created_at"`
 	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
 type StoreNewsRequest struct {
-	ID          int64     `json:"id"`
-	Title       string    `json:"title" validate:"required"`
-	Excerpt     string    `json:"excerpt"`
-	Content     string    `json:"content"`
-	Slug        string    `json:"slug"`
-	Image       string    `json:"image"`
-	Video       string    `json:"video"`
-	Source      string    `json:"source"`
-	Status      string    `json:"status"`
-	Type        string    `json:"type"`
-	Category    string    `json:"category"`
-	Author      User      `json:"author"`
-	Duration    int8      `json:"duration"`
-	StartDate   string    `json:"start_date"`
-	EndDate     string    `json:"end_date"`
-	Tags        []string  `json:"tags"`
-	AreaID      int64     `json:"area_id"`
-	IsLive      int8      `json:"is_live"`
-	PublishedAt NullTime  `json:"published_at"`
-	CreatedBy   User      `json:"created_by"`
-	UpdatedBy   User      `json:"updated_by"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID          int64      `json:"id"`
+	Title       string     `json:"title" validate:"required"`
+	Excerpt     string     `json:"excerpt"`
+	Content     string     `json:"content"`
+	Slug        string     `json:"slug"`
+	Image       string     `json:"image"`
+	Video       string     `json:"video"`
+	Source      string     `json:"source"`
+	Status      string     `json:"status"`
+	Type        string     `json:"type"`
+	Category    string     `json:"category"`
+	Author      User       `json:"author"`
+	Duration    int8       `json:"duration"`
+	StartDate   string     `json:"start_date"`
+	EndDate     string     `json:"end_date"`
+	Tags        []string   `json:"tags"`
+	AreaID      int64      `json:"area_id"`
+	IsLive      int8       `json:"is_live"`
+	PublishedAt *time.Time `json:"published_at"`
+	CreatedBy   User       `json:"created_by"`
+	UpdatedBy   User       `json:"updated_by"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
 // UpdateNewsStatusRequest ...
@@ -81,7 +81,7 @@ type NewsListResponse struct {
 	Status      string     `json:"status"`
 	IsLive      int8       `json:"is_live"`
 	CreatedBy   NullString `json:"created_by"`
-	PublishedAt NullTime   `json:"published_at"`
+	PublishedAt *time.Time `json:"published_at"`
 	CreatedAt   time.Time  `json:"created_at"`
 	UpdatedAt   time.Time  `json:"updated_at"`
 }

--- a/core-service/src/helpers/setters.go
+++ b/core-service/src/helpers/setters.go
@@ -9,12 +9,13 @@ import (
 // SetPropLiveNews ...
 func SetPropLiveNews(news *domain.StoreNewsRequest) {
 
+	currentTime := time.Now()
 	startDate := ConvertStringToTime(news.StartDate)
 
 	// if startDate is less than equal to today, set live to true
 	if startDate.Unix() <= time.Now().Unix() {
 		news.IsLive = 1
-		news.PublishedAt.Time = time.Now()
+		news.PublishedAt = &currentTime
 	}
 
 }

--- a/core-service/src/modules/data-tag/repository/mysql/mysql_data_tag.go
+++ b/core-service/src/modules/data-tag/repository/mysql/mysql_data_tag.go
@@ -85,15 +85,15 @@ func (m *mysqlDataTagRepository) StoreDataTag(ctx context.Context, dt *domain.Da
 	return
 }
 
-func (m *mysqlDataTagRepository) DeleteDataTag(ctx context.Context, id int64) (err error) {
-	query := `DELETE FROM data_tags WHERE data_id=?`
+func (m *mysqlDataTagRepository) DeleteDataTag(ctx context.Context, id int64, domain string) (err error) {
+	query := `DELETE FROM data_tags WHERE data_id=? AND type=?`
 
 	stmt, err := m.Conn.PrepareContext(ctx, query)
 	if err != nil {
 		return
 	}
 
-	_, err = stmt.ExecContext(ctx, id)
+	_, err = stmt.ExecContext(ctx, id, domain)
 	if err != nil {
 		return
 	}

--- a/core-service/src/modules/event/usecase/event_ucase.go
+++ b/core-service/src/modules/event/usecase/event_ucase.go
@@ -155,7 +155,7 @@ func (u *eventUcase) storeTags(ctx context.Context, eventID int64, tags []string
 			DataID:  eventID,
 			TagID:   tag.ID,
 			TagName: tagName,
-			Type:    "events",
+			Type:    "event",
 		}
 		err = u.dataTagRepo.StoreDataTag(ctx, dataTag)
 		if err != nil {
@@ -250,7 +250,7 @@ func (u *eventUcase) Update(c context.Context, id int64, body *domain.StoreReque
 
 	err = u.eventRepo.Update(ctx, id, body)
 
-	err = u.dataTagRepo.DeleteDataTag(ctx, id)
+	err = u.dataTagRepo.DeleteDataTag(ctx, id, "event")
 	if err != nil {
 		return
 	}

--- a/core-service/src/modules/news/repository/mysql/mysql_news.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news.go
@@ -334,7 +334,7 @@ func (m *mysqlNewsRepository) Update(ctx context.Context, id int64, n *domain.St
 		n.EndDate,
 		n.AreaID,
 		n.IsLive,
-		n.PublishedAt.Time,
+		n.PublishedAt,
 		n.Author.ID,
 		time.Now(),
 		id,

--- a/core-service/src/modules/news/repository/mysql/mysql_news_test.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news_test.go
@@ -48,9 +48,9 @@ func TestFetch(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "category", "title", "excerpt", "content", "image", "video", "slug", "author_id", "area_id", "type", "views", "shared", "source", "duration", "start_date", "end_date", "status", "is_live", "published_at", "created_at", "updated_at"}).
 		AddRow(mockNews[0].ID, mockNews[0].Category, mockNews[0].Title, mockNews[0].Excerpt, mockNews[0].Content,
-			nil, nil, mockNews[0].Slug, "", 0, "", mockNews[0].Views, mockNews[0].Shared, mockNews[0].Source.String, 0, mockNews[0].StartDate.Time, mockNews[0].EndDate.Time, mockNews[0].Status, 0, mockNews[0].PublishedAt.Time, mockNews[0].CreatedAt, mockNews[0].UpdatedAt).
+			nil, nil, mockNews[0].Slug, "", 0, "", mockNews[0].Views, mockNews[0].Shared, mockNews[0].Source.String, 0, mockNews[0].StartDate.Time, mockNews[0].EndDate.Time, mockNews[0].Status, 0, mockNews[0].PublishedAt, mockNews[0].CreatedAt, mockNews[0].UpdatedAt).
 		AddRow(mockNews[1].ID, mockNews[1].Category, mockNews[1].Title, mockNews[1].Excerpt, mockNews[1].Content,
-			nil, nil, mockNews[1].Slug, "", 0, "", mockNews[1].Views, mockNews[1].Shared, mockNews[1].Source.String, 0, mockNews[1].StartDate.Time, mockNews[1].EndDate.Time, mockNews[1].Status, 0, mockNews[1].PublishedAt.Time, mockNews[1].CreatedAt, mockNews[1].UpdatedAt)
+			nil, nil, mockNews[1].Slug, "", 0, "", mockNews[1].Views, mockNews[1].Shared, mockNews[1].Source.String, 0, mockNews[1].StartDate.Time, mockNews[1].EndDate.Time, mockNews[1].Status, 0, mockNews[1].PublishedAt, mockNews[1].CreatedAt, mockNews[1].UpdatedAt)
 
 	query := "SELECT id, category, title, excerpt, content, image, video, slug, author_id, area_id, type, views, shared, source, duration, start_date, end_date, status, is_live, published_at, created_at, updated_at FROM news"
 

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -282,6 +282,11 @@ func (n *newsUsecase) TabStatus(ctx context.Context) (res []domain.TabStatusResp
 }
 
 func (n *newsUsecase) storeTags(ctx context.Context, newsId int64, tags []string) (err error) {
+
+	if err := n.dataTagRepo.DeleteDataTag(ctx, newsId); err != nil {
+		logrus.Error(err)
+	}
+
 	for _, tagName := range tags {
 		tag := &domain.Tag{
 			Name: tagName,
@@ -451,7 +456,7 @@ func (n *newsUsecase) Update(c context.Context, id int64, dt *domain.StoreNewsRe
 		return
 	}
 
-	return
+	return n.newsRepo.Update(ctx, id, dt)
 }
 
 func (n *newsUsecase) UpdateStatus(c context.Context, id int64, status string) (err error) {

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -283,10 +283,6 @@ func (n *newsUsecase) TabStatus(ctx context.Context) (res []domain.TabStatusResp
 
 func (n *newsUsecase) storeTags(ctx context.Context, newsId int64, tags []string) (err error) {
 
-	if err := n.dataTagRepo.DeleteDataTag(ctx, newsId); err != nil {
-		logrus.Error(err)
-	}
-
 	for _, tagName := range tags {
 		tag := &domain.Tag{
 			Name: tagName,
@@ -452,8 +448,12 @@ func (n *newsUsecase) Update(c context.Context, id int64, dt *domain.StoreNewsRe
 
 	dt.Slug = news.Slug
 
+	if err := n.dataTagRepo.DeleteDataTag(ctx, id, "news"); err != nil {
+		logrus.Error(err)
+	}
+
 	if err = n.storeTags(ctx, id, dt.Tags); err != nil {
-		return
+		logrus.Error(err)
 	}
 
 	return n.newsRepo.Update(ctx, id, dt)


### PR DESCRIPTION
## Changes
- news: improved store & update
- use pointer of time.Time instead of sql.Nulltime on PublishedAt prop
- passing domain param on delete data tag

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: use pointer of time.Time instead of sql.Nulltime on PublishedAt prop
participants: @khihadysucahyo @rachadiannovansyah @ayocodingit 