### PR TITLE
initialize registration registration feature

### DIFF
--- a/core-service/src/cmd/server/handler.go
+++ b/core-service/src/cmd/server/handler.go
@@ -15,6 +15,7 @@ import (
 	_feedbackHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/feedback/delivery/http"
 	_informationHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/information/delivery/http"
 	_newsHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/news/delivery/http"
+	_regInvitationHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/registration-invitation/delivery/http"
 	_searchHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/search/delivery/http"
 	_tagHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/tag/delivery/http"
 	_unitHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/unit/delivery/http"
@@ -35,6 +36,7 @@ func NewHandler(e *echo.Group, r *echo.Group, u *Usecases) {
 	_userHttpDelivery.NewUserHandler(e, r, u.UserUsecase)
 	_galleryHttpDelivery.NewMediaHandler(e, r, u.MediaUsecase)
 	_tagHttpDelivery.NewTagHandler(e, r, u.TagUsecase)
+	_regInvitationHttpDelivery.NewRegistrationInvitationHandler(e, r, u.RegInvitationUsecase)
 }
 
 // ErrorHandler ...

--- a/core-service/src/cmd/server/repository.go
+++ b/core-service/src/cmd/server/repository.go
@@ -12,6 +12,7 @@ import (
 	_feedbackRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/feedback/repository/mysql"
 	_informationRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/information/repository/mysql"
 	_newsRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/news/repository/mysql"
+	_regInvitationRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/registration-invitation/repository/mysql"
 	_roleRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/role/repository/mysql"
 	_searchRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/search/repository/elastic"
 	_tagRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/tag/repository/mysql"
@@ -34,6 +35,7 @@ type Repository struct {
 	TagRepo             domain.TagRepository
 	SearchRepo          domain.SearchRepository
 	RoleRepo            domain.RoleRepository
+	RegInvitationRepo   domain.RegistrationInvitationRepository
 }
 
 // NewRepository will create an object that represent all repos interface
@@ -52,5 +54,6 @@ func NewRepository(conn *utils.Conn) *Repository {
 		TagRepo:             _tagRepo.NewMysqlTagRepository(conn.Mysql),
 		SearchRepo:          _searchRepo.NewElasticSearchRepository(conn.Elastic),
 		RoleRepo:            _roleRepo.NewMysqlRoleRepository(conn.Mysql),
+		RegInvitationRepo:   _regInvitationRepo.NewMysqlRegInvitationRepository(conn.Mysql),
 	}
 }

--- a/core-service/src/cmd/server/usecase.go
+++ b/core-service/src/cmd/server/usecase.go
@@ -15,6 +15,7 @@ import (
 	_informationUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/information/usecase"
 	_mediaUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/media/usecase"
 	_newsUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/news/usecase"
+	_regInvitationUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/registration-invitation/usecase"
 	_searchUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/search/usecase"
 	_tagUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/tag/usecase"
 	_unitUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/unit/usecase"
@@ -36,6 +37,7 @@ type Usecases struct {
 	UserUsecase          domain.UserUsecase
 	MediaUsecase         domain.MediaUsecase
 	TagUsecase           domain.TagUsecase
+	RegInvitationUsecase domain.RegistrationInvitationUsecase
 }
 
 // NewUcase will create an object that represent all usecases interface
@@ -53,5 +55,6 @@ func NewUcase(cfg *config.Config, conn *utils.Conn, r *Repository, timeoutContex
 		UserUsecase:          _userUcase.NewUserkUsecase(r.UserRepo, r.UnitRepo, r.RoleRepo, timeoutContext),
 		MediaUsecase:         _mediaUcase.NewMediaUsecase(cfg, conn, timeoutContext),
 		TagUsecase:           _tagUcase.NewTagUsecase(r.TagRepo, timeoutContext),
+		RegInvitationUsecase: _regInvitationUcase.NewRegInvitationUsecase(r.RegInvitationRepo, r.UserRepo, timeoutContext),
 	}
 }

--- a/core-service/src/database/migrations/20220322120539_create_reg_invitations_table.down.sql
+++ b/core-service/src/database/migrations/20220322120539_create_reg_invitations_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE registration_invitations;

--- a/core-service/src/database/migrations/20220322120539_create_reg_invitations_table.up.sql
+++ b/core-service/src/database/migrations/20220322120539_create_reg_invitations_table.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+CREATE TABLE registration_invitations (
+  id INT(10) unsigned NOT NULL AUTO_INCREMENT,
+  email VARCHAR(80) NOT NULL,
+  token VARCHAR(255),
+  expired_at TIMESTAMP NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+);
+CREATE INDEX idx_email ON registration_invitations(email);
+CREATE INDEX idx_token ON registration_invitations(token);
+COMMIT;

--- a/core-service/src/domain/errors.go
+++ b/core-service/src/domain/errors.go
@@ -14,3 +14,11 @@ var (
 	// ErrInvalidCredentials
 	ErrInvalidCredentials = errors.New("Invalid credentials")
 )
+
+type ErrResponse struct {
+	Message string `json:"message"`
+}
+
+func NewErrResponse(err error) *ErrResponse {
+	return &ErrResponse{Message: err.Error()}
+}

--- a/core-service/src/domain/registration_invitation.go
+++ b/core-service/src/domain/registration_invitation.go
@@ -1,0 +1,26 @@
+package domain
+
+import (
+	"context"
+	"time"
+)
+
+type RegistrationInvitation struct {
+	ID        int64     `json:"id"`
+	Email     string    `json:"email"`
+	Token     string    `json:"token"`
+	ExpiredAt time.Time `json:"expired_at"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type RegistrationInvitationRepository interface {
+	GetByEmail(ctx context.Context, email string) (RegistrationInvitation, error)
+	GetByToken(ctx context.Context, token string) (RegistrationInvitation, error)
+	Store(ctx context.Context, invitation *RegistrationInvitation) error
+	Update(ctx context.Context, id int64, invitation *RegistrationInvitation) error
+}
+
+type RegistrationInvitationUsecase interface {
+	Invite(ctx context.Context, email string) (RegistrationInvitation, error)
+}

--- a/core-service/src/modules/registration-invitation/delivery/http/mysql_registration_handler.go
+++ b/core-service/src/modules/registration-invitation/delivery/http/mysql_registration_handler.go
@@ -1,0 +1,38 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/labstack/echo/v4"
+)
+
+type RegistrationInvitationHandler struct {
+	IUsecase domain.RegistrationInvitationUsecase
+}
+
+func NewRegistrationInvitationHandler(e *echo.Group, r *echo.Group, us domain.RegistrationInvitationUsecase) {
+	handler := &RegistrationInvitationHandler{
+		IUsecase: us,
+	}
+	r.POST("/registration-invitations", handler.Invite)
+}
+
+func (r *RegistrationInvitationHandler) Invite(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	var regInvitation domain.RegistrationInvitation
+	err := c.Bind(&regInvitation)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, domain.NewErrResponse(err))
+	}
+
+	_, err = r.IUsecase.Invite(ctx, regInvitation.Email)
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, domain.NewErrResponse(err))
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"message": "invitation sent",
+	})
+}

--- a/core-service/src/modules/registration-invitation/delivery/http/registration_invitation_handler.go
+++ b/core-service/src/modules/registration-invitation/delivery/http/registration_invitation_handler.go
@@ -27,12 +27,13 @@ func (r *RegistrationInvitationHandler) Invite(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, domain.NewErrResponse(err))
 	}
 
-	_, err = r.IUsecase.Invite(ctx, regInvitation.Email)
+	res, err := r.IUsecase.Invite(ctx, regInvitation.Email)
 	if err != nil {
 		return c.JSON(http.StatusUnprocessableEntity, domain.NewErrResponse(err))
 	}
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"message": "invitation sent",
+		"token":   res.Token, // FIXME: should be delete this response after implement email service
 	})
 }

--- a/core-service/src/modules/registration-invitation/repository/mysql/mysql_registration_invitation.go
+++ b/core-service/src/modules/registration-invitation/repository/mysql/mysql_registration_invitation.go
@@ -1,0 +1,129 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/sirupsen/logrus"
+)
+
+type mysqlRegInvitationRepository struct {
+	Conn *sql.DB
+}
+
+func NewMysqlRegInvitationRepository(Conn *sql.DB) domain.RegistrationInvitationRepository {
+	return &mysqlRegInvitationRepository{Conn}
+}
+
+var querySelectRegistrationInvitation = `
+	SELECT id, email, token, expired_at, created_at, updated_at FROM registration_invitations WHERE 1=1
+`
+
+func (m *mysqlRegInvitationRepository) findOne(ctx context.Context,
+	query string, args ...interface{}) (result domain.RegistrationInvitation, err error) {
+
+	rows, err := m.Conn.QueryContext(ctx, query, args...)
+	if err != nil {
+		logrus.Error(err)
+		return result, err
+	}
+
+	defer func() {
+		errRow := rows.Close()
+		if errRow != nil {
+			logrus.Error(errRow)
+		}
+	}()
+
+	if rows.Next() {
+		err = rows.Scan(
+			&result.ID,
+			&result.Email,
+			&result.Token,
+			&result.ExpiredAt,
+			&result.CreatedAt,
+			&result.UpdatedAt,
+		)
+		if err != nil {
+			logrus.Error(err)
+			return result, err
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mysqlRegInvitationRepository) GetByEmail(ctx context.Context,
+	email string) (result domain.RegistrationInvitation, err error) {
+
+	query := querySelectRegistrationInvitation + " AND email=?"
+	return m.findOne(ctx, query, email)
+}
+
+func (m *mysqlRegInvitationRepository) GetByToken(ctx context.Context,
+	token string) (result domain.RegistrationInvitation, err error) {
+
+	query := querySelectRegistrationInvitation + " AND token=?"
+	return m.findOne(ctx, query, token)
+}
+
+func (m *mysqlRegInvitationRepository) Store(ctx context.Context,
+	registrationInvitation *domain.RegistrationInvitation) (err error) {
+
+	query := `INSERT INTO registration_invitations (email, token, expired_at) VALUES (?, ?, ?)`
+	res, err := m.Conn.ExecContext(
+		ctx,
+		query,
+		registrationInvitation.Email,
+		registrationInvitation.Token,
+		registrationInvitation.ExpiredAt,
+	)
+
+	if err != nil {
+		logrus.Error(err)
+		return err
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		logrus.Error(err)
+		return
+	}
+
+	registrationInvitation.ID = id
+
+	return
+}
+
+func (m *mysqlRegInvitationRepository) Update(ctx context.Context,
+	id int64, registrationInvitation *domain.RegistrationInvitation) (err error) {
+
+	query := `UPDATE registration_invitations SET email=?, token=?, expired_at=?, updated_at=? WHERE id=?`
+	res, err := m.Conn.ExecContext(
+		ctx,
+		query,
+		registrationInvitation.Email,
+		registrationInvitation.Token,
+		registrationInvitation.ExpiredAt,
+		registrationInvitation.UpdatedAt,
+		id,
+	)
+
+	if err != nil {
+		logrus.Error(err)
+		return err
+	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		logrus.Error(err)
+		return
+	}
+
+	if rowsAffected == 0 {
+		return domain.ErrNotFound
+	}
+
+	return
+}

--- a/core-service/src/modules/registration-invitation/usecase/registration_invitation_ucase.go
+++ b/core-service/src/modules/registration-invitation/usecase/registration_invitation_ucase.go
@@ -35,17 +35,17 @@ func (r *regInvitationUcase) generateInvitationToken() (string, error) {
 }
 
 func (r *regInvitationUcase) Invite(ctx context.Context,
-	email string) (result domain.RegistrationInvitation, err error) {
+	email string) (regInvitation domain.RegistrationInvitation, err error) {
 
 	// validate if email is already registered in users table
 	if u, _ := r.userRepo.GetByEmail(ctx, email); u.Email != "" {
-		return result, errors.New("email already registered")
+		return regInvitation, errors.New("email already registered")
 	}
 
 	// find if email is already registered in registration_invitation table
-	regInvitation, err := r.regInvitationRepo.GetByEmail(ctx, email)
+	regInvitation, err = r.regInvitationRepo.GetByEmail(ctx, email)
 	if err != nil {
-		return result, err
+		return regInvitation, err
 	}
 
 	// prepare registration invitation data

--- a/core-service/src/modules/registration-invitation/usecase/registration_invitation_ucase.go
+++ b/core-service/src/modules/registration-invitation/usecase/registration_invitation_ucase.go
@@ -1,0 +1,66 @@
+package usecase
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+)
+
+type regInvitationUcase struct {
+	regInvitationRepo domain.RegistrationInvitationRepository
+	userRepo          domain.UserRepository
+	contextTimeout    time.Duration
+}
+
+func NewRegInvitationUsecase(regInvitationRepo domain.RegistrationInvitationRepository,
+	userRepo domain.UserRepository, contextTimeout time.Duration) domain.RegistrationInvitationUsecase {
+	return &regInvitationUcase{
+		regInvitationRepo: regInvitationRepo,
+		userRepo:          userRepo,
+		contextTimeout:    contextTimeout,
+	}
+}
+
+func (r *regInvitationUcase) generateInvitationToken() (string, error) {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
+}
+
+func (r *regInvitationUcase) Invite(ctx context.Context,
+	email string) (result domain.RegistrationInvitation, err error) {
+
+	// validate if email is already registered in users table
+	if u, _ := r.userRepo.GetByEmail(ctx, email); u.Email != "" {
+		return result, errors.New("email already registered")
+	}
+
+	// find if email is already registered in registration_invitation table
+	regInvitation, err := r.regInvitationRepo.GetByEmail(ctx, email)
+	if err != nil {
+		return result, err
+	}
+
+	// prepare registration invitation data
+	regInvitation.Email = email
+	regInvitation.Token, _ = r.generateInvitationToken()
+	regInvitation.ExpiredAt = time.Now().Add(time.Hour * 24 * 5) // expired in 5 days
+
+	// update invitation if email already exist
+	if regInvitation.ID > 0 {
+		err = r.regInvitationRepo.Update(ctx, regInvitation.ID, &regInvitation)
+	} else {
+		err = r.regInvitationRepo.Store(ctx, &regInvitation)
+	}
+
+	// TODO: dispatch job to send email invitation
+
+	return
+}


### PR DESCRIPTION
## Overview
initialize registration registration feature

## Changes
- added domain: registration-invitation
- added migration to create registration_invitations table
- added repo interface to handle data manipulation in registration_invitations table
- added invate usecase to handle logic of invitation
- added temporary providing token on invitation response

## Todo
- Create Jobs/SendMailInvitation
- Job Dispatcher
- Interface to verify registration token

## FIXME
- should be delete invitation token on this response after implement email service

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: added PublishedAt prop on headline/newsbanner
participants: @khihadysucahyo @rachadiannovansyah @ayocodingit 