### PR TITLE
Enchancement API list member invitation

### DIFF
--- a/core-service/src/database/migrations/20220329011016_add_last_active_on_users_table.down.sql
+++ b/core-service/src/database/migrations/20220329011016_add_last_active_on_users_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN last_active;

--- a/core-service/src/database/migrations/20220329011016_add_last_active_on_users_table.up.sql
+++ b/core-service/src/database/migrations/20220329011016_add_last_active_on_users_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD last_active TIMESTAMP NULL AFTER last_password_changed;

--- a/core-service/src/domain/user.go
+++ b/core-service/src/domain/user.go
@@ -47,7 +47,7 @@ type MemberList struct {
 	Email      string     `json:"email"`
 	Role       string     `json:"role"`
 	LastActive *time.Time `json:"last_active"`
-	Status     *string    `json:"status"`
+	Status     string     `json:"status"`
 }
 
 type AccountSubmission struct {

--- a/core-service/src/domain/user.go
+++ b/core-service/src/domain/user.go
@@ -43,7 +43,7 @@ type UserInfo struct {
 
 type MemberList struct {
 	ID         uuid.UUID  `json:"id"`
-	Name       string     `json:"name"`
+	Name       *string    `json:"name"`
 	Email      string     `json:"email"`
 	Role       string     `json:"role"`
 	LastActive *time.Time `json:"last_active"`
@@ -74,6 +74,7 @@ type UserRepository interface {
 	Store(context.Context, *User) error
 	Update(context.Context, *User) error
 	MemberList(context.Context, *Request) ([]MemberList, int64, error)
+	WriteLastActive(context.Context, time.Time, *User) error
 }
 
 // UserUsecase ...

--- a/core-service/src/modules/auth/usecase/auth_ucase.go
+++ b/core-service/src/modules/auth/usecase/auth_ucase.go
@@ -95,6 +95,13 @@ func (n *authUsecase) Login(c context.Context, req *domain.LoginRequest) (res do
 
 	refreshToken, err := n.createRefreshToken(&user)
 
+	// write last active
+	timeNow := time.Now()
+	err = n.userRepo.WriteLastActive(c, timeNow, &user)
+	if err != nil {
+		return domain.LoginResponse{}, err
+	}
+
 	res = newLoginResponse(accessToken, refreshToken, exp)
 
 	return

--- a/core-service/src/modules/user/repository/mysql/mysql_user.go
+++ b/core-service/src/modules/user/repository/mysql/mysql_user.go
@@ -106,13 +106,13 @@ func (m *mysqlUserRepository) Update(ctx context.Context, u *domain.User) (err e
 }
 
 func (m *mysqlUserRepository) MemberList(ctx context.Context, params *domain.Request) (res []domain.MemberList, total int64, err error) {
-	queryUnion := `SELECT member.id, member.name, member.email, member.role_name 
+	queryUnion := `SELECT member.id, member.name, member.email, member.role_name , member.status
 	FROM (
-		select users.id, users.name, users.email, roles.name as role_name
+		select users.id, users.name, users.email, roles.name as role_name, "active" as status
 		FROM users
 		LEFT JOIN roles ON roles.id = users.role_id 
 		UNION ALL
-		SELECT id, "", email, ""
+		SELECT id, "", email, "Member", "waiting confirmation"
 		FROM registration_invitations
 	) member`
 
@@ -172,6 +172,7 @@ func (m *mysqlUserRepository) fetch(ctx context.Context, query string, args ...i
 			&t.Name,
 			&t.Email,
 			&t.Role,
+			&t.Status,
 		)
 
 		if err != nil {

--- a/core-service/src/modules/user/repository/mysql/mysql_user.go
+++ b/core-service/src/modules/user/repository/mysql/mysql_user.go
@@ -112,7 +112,7 @@ func (m *mysqlUserRepository) MemberList(ctx context.Context, params *domain.Req
 		FROM users
 		LEFT JOIN roles ON roles.id = users.role_id 
 		UNION ALL
-		SELECT id, "", email, "Member", "waiting confirmation"
+		SELECT id, null, email, "Member", "waiting confirmation"
 		FROM registration_invitations
 	) member`
 
@@ -138,7 +138,7 @@ func (m *mysqlUserRepository) MemberList(ctx context.Context, params *domain.Req
 									UNION ALL
 									SELECT id
 									FROM registration_invitations
-							) member ORDER BY id ASC;`)
+							) member ORDER BY id ASC`)
 
 	queryUnion = queryUnion + ` LIMIT ?,? `
 


### PR DESCRIPTION
Overview:
- adjust value name invitation null instead of empty string
- add new column migration `last_active` on user
- write last_active login user
- get value last_active on endpoint api get member list

Evidence:
project: Portal Jabar
title: add last active on users login & get it from api endpoint memberlist invitation
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 