### PR TITLE
create endpoint to set user as administrator

### DIFF
--- a/core-service/src/domain/user.go
+++ b/core-service/src/domain/user.go
@@ -83,6 +83,10 @@ type ChangePasswordRequest struct {
 	NewPassword     string `json:"new_password" validate:"required"`
 }
 
+type CheckPasswordRequest struct {
+	Password string `json:"password"`
+}
+
 type CheckNipExistRequest struct {
 	Nip *string `json:"nip" validate:"len=18"`
 }
@@ -97,6 +101,7 @@ type UserRepository interface {
 	WriteLastActive(context.Context, time.Time, *User) error
 	UserList(context.Context, *Request) ([]User, int64, error)
 	GetUserByID(context.Context, uuid.UUID) (User, error)
+	SetAsAdmin(context.Context, uuid.UUID, int8) error
 }
 
 // UserUsecase ...
@@ -110,4 +115,5 @@ type UserUsecase interface {
 	RegisterByInvitation(ctx context.Context, user *User) error // domain mana yach?
 	UserList(ctx context.Context, params *Request) (res []User, total int64, err error)
 	GetUserByID(ctx context.Context, id uuid.UUID) (res User, err error)
+	SetAsAdmin(context.Context, uuid.UUID, *CheckPasswordRequest, uuid.UUID, int8) error
 }

--- a/core-service/src/modules/user/repository/mysql/mysql_user.go
+++ b/core-service/src/modules/user/repository/mysql/mysql_user.go
@@ -237,3 +237,18 @@ func (m *mysqlUserRepository) GetUserByID(ctx context.Context, id uuid.UUID) (re
 
 	return
 }
+
+func (m *mysqlUserRepository) SetAsAdmin(ctx context.Context, id uuid.UUID, role int8) (err error) {
+	query := `UPDATE users SET role_id=? WHERE id = ?`
+	stmt, err := m.Conn.PrepareContext(ctx, query)
+	if err != nil {
+		return
+	}
+
+	_, err = stmt.ExecContext(ctx, role, id)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/core-service/src/modules/user/usecase/user_usecase.go
+++ b/core-service/src/modules/user/usecase/user_usecase.go
@@ -276,3 +276,22 @@ func (u *userUsecase) CheckIfNipExists(c context.Context, nip *string) (res bool
 
 	return
 }
+
+func (n *userUsecase) SetAsAdmin(c context.Context, currUser uuid.UUID, req *domain.CheckPasswordRequest, userID uuid.UUID, roleID int8) (err error) {
+	ctx, cancel := context.WithTimeout(c, n.contextTimeout)
+	defer cancel()
+
+	user, err := n.userRepo.GetByID(ctx, currUser)
+	if err != nil {
+		return err
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(req.Password))
+	if err != nil {
+		return err
+	}
+
+	err = n.userRepo.SetAsAdmin(ctx, userID, roleID)
+
+	return
+}


### PR DESCRIPTION
Overview:
- add endpoint to set user as administrator
- add validation current change password

cc: @jabardigitalservice/jds-backend 

Evidence:
project: Portal Jabar
title: create endpoint to set user as administrator
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 