### PR TITLE
create endpoint change email user partial

### DIFF
--- a/core-service/src/domain/user.go
+++ b/core-service/src/domain/user.go
@@ -84,7 +84,8 @@ type ChangePasswordRequest struct {
 }
 
 type CheckPasswordRequest struct {
-	Password string `json:"password"`
+	NewEmail string `json:"new_email" validate:"required"`
+	Password string `json:"password" validate:"required"`
 }
 
 type CheckNipExistRequest struct {
@@ -102,6 +103,7 @@ type UserRepository interface {
 	UserList(context.Context, *Request) ([]User, int64, error)
 	GetUserByID(context.Context, uuid.UUID) (User, error)
 	SetAsAdmin(context.Context, uuid.UUID, int8) error
+	ChangeEmail(context.Context, uuid.UUID, string) error
 }
 
 // UserUsecase ...
@@ -116,4 +118,5 @@ type UserUsecase interface {
 	UserList(ctx context.Context, params *Request) (res []User, total int64, err error)
 	GetUserByID(ctx context.Context, id uuid.UUID) (res User, err error)
 	SetAsAdmin(context.Context, uuid.UUID, *CheckPasswordRequest, uuid.UUID, int8) error
+	ChangeEmail(context.Context, uuid.UUID, *CheckPasswordRequest, uuid.UUID) error
 }

--- a/core-service/src/helpers/helper.go
+++ b/core-service/src/helpers/helper.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"errors"
+	"net/mail"
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
 )
@@ -11,4 +12,12 @@ func IsInvitationTokenValid(regInvitation domain.RegistrationInvitation, token s
 		return errors.New("invalid token")
 	}
 	return nil
+}
+
+func IsValidMailAddress(address string) (string, bool) {
+	addr, err := mail.ParseAddress(address)
+	if err != nil {
+		return "", false
+	}
+	return addr.Address, true
 }

--- a/core-service/src/modules/user/repository/mysql/mysql_user.go
+++ b/core-service/src/modules/user/repository/mysql/mysql_user.go
@@ -252,3 +252,18 @@ func (m *mysqlUserRepository) SetAsAdmin(ctx context.Context, id uuid.UUID, role
 
 	return
 }
+
+func (m *mysqlUserRepository) ChangeEmail(ctx context.Context, id uuid.UUID, email string) (err error) {
+	query := `UPDATE users SET email=? WHERE id = ?`
+	stmt, err := m.Conn.PrepareContext(ctx, query)
+	if err != nil {
+		return
+	}
+
+	_, err = stmt.ExecContext(ctx, email, id)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/core-service/src/modules/user/usecase/user_usecase.go
+++ b/core-service/src/modules/user/usecase/user_usecase.go
@@ -315,11 +315,16 @@ func (n *userUsecase) ChangeEmail(c context.Context, id uuid.UUID, req *domain.C
 		return
 	}
 
-	if u, _ := n.userRepo.GetByEmail(ctx, req.NewEmail); u.Email != "" {
+	newEmail := req.NewEmail
+	if _, ok := helpers.IsValidMailAddress(newEmail); !ok {
+		return errors.New("invalid email format")
+	}
+
+	if u, _ := n.userRepo.GetByEmail(ctx, newEmail); u.Email != "" {
 		return errors.New("email already registered")
 	}
 
-	err = n.userRepo.ChangeEmail(ctx, userID, req.NewEmail)
+	err = n.userRepo.ChangeEmail(ctx, userID, newEmail)
 
 	return
 }

--- a/core-service/src/modules/user/usecase/user_usecase.go
+++ b/core-service/src/modules/user/usecase/user_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -312,6 +313,10 @@ func (n *userUsecase) ChangeEmail(c context.Context, id uuid.UUID, req *domain.C
 	_, err = n.isValidUser(ctx, req, id)
 	if err != nil {
 		return
+	}
+
+	if u, _ := n.userRepo.GetByEmail(ctx, req.NewEmail); u.Email != "" {
+		return errors.New("email already registered")
 	}
 
 	err = n.userRepo.ChangeEmail(ctx, userID, req.NewEmail)

--- a/core-service/src/modules/user/usecase/user_usecase.go
+++ b/core-service/src/modules/user/usecase/user_usecase.go
@@ -45,6 +45,20 @@ func encryptPassword(password string) (string, error) {
 	return string(encryptedPassword), nil
 }
 
+func (n *userUsecase) isValidUser(ctx context.Context, req *domain.CheckPasswordRequest, id uuid.UUID) (ok bool, err error) {
+	user, err := n.userRepo.GetByID(ctx, id)
+	if err != nil {
+		return
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(req.Password))
+	if err != nil {
+		return
+	}
+
+	return
+}
+
 func (u *userUsecase) Store(c context.Context, usr *domain.User) (err error) {
 	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
 	defer cancel()
@@ -277,21 +291,30 @@ func (u *userUsecase) CheckIfNipExists(c context.Context, nip *string) (res bool
 	return
 }
 
-func (n *userUsecase) SetAsAdmin(c context.Context, currUser uuid.UUID, req *domain.CheckPasswordRequest, userID uuid.UUID, roleID int8) (err error) {
+func (n *userUsecase) SetAsAdmin(c context.Context, id uuid.UUID, req *domain.CheckPasswordRequest, userID uuid.UUID, roleID int8) (err error) {
 	ctx, cancel := context.WithTimeout(c, n.contextTimeout)
 	defer cancel()
 
-	user, err := n.userRepo.GetByID(ctx, currUser)
+	_, err = n.isValidUser(ctx, req, id)
 	if err != nil {
-		return err
-	}
-
-	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(req.Password))
-	if err != nil {
-		return err
+		return
 	}
 
 	err = n.userRepo.SetAsAdmin(ctx, userID, roleID)
+
+	return
+}
+
+func (n *userUsecase) ChangeEmail(c context.Context, id uuid.UUID, req *domain.CheckPasswordRequest, userID uuid.UUID) (err error) {
+	ctx, cancel := context.WithTimeout(c, n.contextTimeout)
+	defer cancel()
+
+	_, err = n.isValidUser(ctx, req, id)
+	if err != nil {
+		return
+	}
+
+	err = n.userRepo.ChangeEmail(ctx, userID, req.NewEmail)
 
 	return
 }


### PR DESCRIPTION
Overview:
- add endpoint to change email user
- check user password is valid to process change email user
- check unique email & check valid email format

Evidence: 
project: Portal Jabar
title: create endpoint change email user partial
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 