### PR TITLE
set permission to endpoints user, news, agenda

### DIFF
--- a/core-service/src/domain/permission.go
+++ b/core-service/src/domain/permission.go
@@ -1,5 +1,10 @@
 package domain
 
 var (
-	PermissionInviteUser = "user.invite"
+	PermissionInviteUser       = "user.invite"
+	PermissionSetAsAdmin       = "user.set_as_admin"
+	PermissionChangeEmail      = "user.change_email"
+	PermissionActivateAccount  = "user.activate_account"
+	PermissionManageUser       = "user.manage_user"
+	PermissionRequestToBeAdmin = "user.request_to_be_admin"
 )

--- a/core-service/src/domain/permission.go
+++ b/core-service/src/domain/permission.go
@@ -1,6 +1,6 @@
 package domain
 
-var (
+const (
 	PermissionInviteUser       = "user.invite"
 	PermissionSetAsAdmin       = "user.set_as_admin"
 	PermissionChangeEmail      = "user.change_email"

--- a/core-service/src/domain/permission.go
+++ b/core-service/src/domain/permission.go
@@ -1,10 +1,12 @@
 package domain
 
 const (
+	PermissionManageNews       = "news.manage"
+	PermissionManageEvent      = "event.manage"
+	PermissionManageUser       = "user.manage"
 	PermissionInviteUser       = "user.invite"
-	PermissionSetAsAdmin       = "user.set_as_admin"
-	PermissionChangeEmail      = "user.change_email"
-	PermissionActivateAccount  = "user.activate_account"
-	PermissionManageUser       = "user.manage_user"
-	PermissionRequestToBeAdmin = "user.request_to_be_admin"
+	PermissionSetAsAdmin       = "user.set-as-admin"
+	PermissionChangeEmail      = "user.change-email"
+	PermissionActivateAccount  = "user.activate-account"
+	PermissionRequestToBeAdmin = "user.request-to-be-admin"
 )

--- a/core-service/src/modules/event/delivery/http/event_handler.go
+++ b/core-service/src/modules/event/delivery/http/event_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
+	middl "github.com/jabardigitalservice/portal-jabar-services/core-service/src/middleware"
 	"github.com/jinzhu/copier"
 	"github.com/labstack/echo/v4"
 	validator "gopkg.in/go-playground/validator.v9"
@@ -23,12 +24,16 @@ func NewEventHandler(e *echo.Group, r *echo.Group, us domain.EventUsecase) {
 	handler := &EventHandler{
 		EventUcase: us,
 	}
+	permManageEvent := domain.PermissionManageEvent
 
-	e.GET("/events", handler.Fetch)
-	e.GET("/events/:id", handler.GetByID)
-	r.POST("/events", handler.Store)
-	e.DELETE("/events/:id", handler.Delete)
-	e.PUT("/events/:id", handler.Update)
+	// Cms ...
+	r.GET("/events", handler.Fetch, middl.CheckPermission(permManageEvent))
+	r.GET("/events/:id", handler.GetByID, middl.CheckPermission(permManageEvent))
+	r.POST("/events", handler.Store, middl.CheckPermission(permManageEvent))
+	r.DELETE("/events/:id", handler.Delete, middl.CheckPermission(permManageEvent))
+	r.PUT("/events/:id", handler.Update, middl.CheckPermission(permManageEvent))
+
+	// Portal ...
 	e.GET("/events/calendar", handler.AgendaCalendar)
 	e.GET("/events/portal", handler.AgendaPortal)
 }

--- a/core-service/src/modules/news/delivery/http/news_handler.go
+++ b/core-service/src/modules/news/delivery/http/news_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
+	middl "github.com/jabardigitalservice/portal-jabar-services/core-service/src/middleware"
 )
 
 // NewsHandler ...
@@ -33,17 +34,22 @@ func NewNewsHandler(e *echo.Group, r *echo.Group, us domain.NewsUsecase) {
 	handler := &NewsHandler{
 		CUsecase: us,
 	}
-	e.GET("/news", handler.FetchNews)
-	r.POST("/news", handler.Store)
-	e.GET("/news/:id", handler.GetByID)
-	r.PUT("/news/:id", handler.Update)
-	r.PATCH("/news/:id/status", handler.UpdateStatus)
+	permManageNews := domain.PermissionManageNews
+
+	// Cms ...
+	e.GET("/news", handler.FetchNews) // TO DO separate this endpoint to fetch between CMS and PORTAL
+	r.POST("/news", handler.Store, middl.CheckPermission(permManageNews))
+	r.GET("/news/:id", handler.GetByID, middl.CheckPermission(permManageNews))
+	r.PUT("/news/:id", handler.Update, middl.CheckPermission(permManageNews))
+	r.DELETE("/news/:id", handler.Delete, middl.CheckPermission(permManageNews))
+	r.PATCH("/news/:id/status", handler.UpdateStatus) // TO DO permission update status has multiple values
 	e.GET("/news/slug/:slug", handler.GetBySlug)
+	e.GET("/news/tabs", handler.TabStatus)
+
+	// Portal ...
 	e.GET("/news/banner", handler.FetchNewsBanner)
 	e.GET("/news/headline", handler.FetchNewsHeadline)
 	e.PATCH("/news/:id/share", handler.AddShare)
-	e.GET("/news/tabs", handler.TabStatus)
-	e.DELETE("/news/:id", handler.Delete)
 }
 
 // FetchNews will fetch the content based on given params

--- a/core-service/src/modules/user/delivery/http/user_handler.go
+++ b/core-service/src/modules/user/delivery/http/user_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	uuid "github.com/google/uuid"
+	middl "github.com/jabardigitalservice/portal-jabar-services/core-service/src/middleware"
 	"github.com/jinzhu/copier"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
@@ -27,13 +28,13 @@ func NewUserHandler(e *echo.Group, r *echo.Group, uu domain.UserUsecase) {
 	r.GET("/users/me", handler.UserProfile)
 	r.PUT("/users/me", handler.UpdateProfile)
 	r.PUT("/users/me/change-password", handler.ChangePassword)
-	r.PUT("/users/me/account-submission", handler.AccountSubmission)
+	r.PUT("/users/me/account-submission", handler.AccountSubmission, middl.CheckPermission(domain.PermissionRequestToBeAdmin))
 	e.POST("/users/register", handler.Register)
-	r.GET("/users", handler.UserList)
-	r.GET("/users/:id", handler.GetByID)
-	r.PUT("/users/:id/set-as-admin", handler.SetAsAdmin)
-	r.PUT("/users/:id/change-email", handler.ChangeEmail)
-	r.PUT("/users/:id/activate-account", handler.ActivateAccount)
+	r.GET("/users", handler.UserList, middl.CheckPermission(domain.PermissionManageUser))
+	r.GET("/users/:id", handler.GetByID, middl.CheckPermission(domain.PermissionManageUser))
+	r.PUT("/users/:id/set-as-admin", handler.SetAsAdmin, middl.CheckPermission(domain.PermissionSetAsAdmin))
+	r.PUT("/users/:id/change-email", handler.ChangeEmail, middl.CheckPermission(domain.PermissionChangeEmail))
+	r.PUT("/users/:id/activate-account", handler.ActivateAccount, middl.CheckPermission(domain.PermissionActivateAccount))
 	e.POST("/users/check-nip-exists", handler.CheckNipExists)
 }
 


### PR DESCRIPTION
## Overview
set permission to endpoints (users, news, agenda

## Changes
set permission to endpoint:
Users:
- List User
- Get User By Id
- Set User As Admin
- Change User Email
- Activate / Deactivate User

Agenda:
- List Agenda
- Get Agenda By Id
- Store Agenda
- Update Agenda
- Delete Agenda

News:
- Store News
- Get News By Id
- Update News
- Delete News

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: set permission to endpoints users, news, agenda
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 