### PR TITLE
fix change-status permission instead of activate-account

### DIFF
--- a/core-service/src/domain/permission.go
+++ b/core-service/src/domain/permission.go
@@ -7,6 +7,6 @@ const (
 	PermissionInviteUser       = "user.invite"
 	PermissionSetAsAdmin       = "user.set-as-admin"
 	PermissionChangeEmail      = "user.change-email"
-	PermissionActivateAccount  = "user.activate-account"
+	PermissionChangeStatus     = "user.change-status"
 	PermissionRequestToBeAdmin = "user.request-to-be-admin"
 )

--- a/core-service/src/domain/user.go
+++ b/core-service/src/domain/user.go
@@ -105,7 +105,7 @@ type UserRepository interface {
 	GetUserByID(context.Context, uuid.UUID) (User, error)
 	SetAsAdmin(context.Context, uuid.UUID, int8) error
 	ChangeEmail(context.Context, uuid.UUID, string) error
-	ActivateAccount(context.Context, uuid.UUID, string) error
+	ChangeStatus(context.Context, uuid.UUID, string) error
 }
 
 // UserUsecase ...
@@ -121,5 +121,5 @@ type UserUsecase interface {
 	GetUserByID(ctx context.Context, id uuid.UUID) (res User, err error)
 	SetAsAdmin(context.Context, uuid.UUID, *CheckPasswordRequest, uuid.UUID) error
 	ChangeEmail(context.Context, uuid.UUID, *CheckPasswordRequest, uuid.UUID) error
-	ActivateAccount(context.Context, uuid.UUID, *CheckPasswordRequest, uuid.UUID) error
+	ChangeStatus(context.Context, uuid.UUID, *CheckPasswordRequest, uuid.UUID) error
 }

--- a/core-service/src/modules/user/delivery/http/user_handler.go
+++ b/core-service/src/modules/user/delivery/http/user_handler.go
@@ -34,7 +34,7 @@ func NewUserHandler(e *echo.Group, r *echo.Group, uu domain.UserUsecase) {
 	r.GET("/users/:id", handler.GetByID, middl.CheckPermission(domain.PermissionManageUser))
 	r.PUT("/users/:id/set-as-admin", handler.SetAsAdmin, middl.CheckPermission(domain.PermissionSetAsAdmin))
 	r.PUT("/users/:id/change-email", handler.ChangeEmail, middl.CheckPermission(domain.PermissionChangeEmail))
-	r.PUT("/users/:id/activate-account", handler.ActivateAccount, middl.CheckPermission(domain.PermissionActivateAccount))
+	r.PUT("/users/:id/change-status", handler.ChangeStatus, middl.CheckPermission(domain.PermissionChangeStatus))
 	e.POST("/users/check-nip-exists", handler.CheckNipExists)
 }
 
@@ -255,7 +255,7 @@ func (h *UserHandler) ChangeEmail(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"message": "email changed"})
 }
 
-func (h *UserHandler) ActivateAccount(c echo.Context) error {
+func (h *UserHandler) ChangeStatus(c echo.Context) error {
 	req := new(domain.CheckPasswordRequest)
 	if err := c.Bind(req); err != nil {
 		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
@@ -269,7 +269,7 @@ func (h *UserHandler) ActivateAccount(c echo.Context) error {
 	au := helpers.GetAuthenticatedUser(c)
 	userID := uuid.MustParse(c.Param("id"))
 
-	err := h.UUsecase.ActivateAccount(ctx, au.ID, req, userID)
+	err := h.UUsecase.ChangeStatus(ctx, au.ID, req, userID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
 	}

--- a/core-service/src/modules/user/repository/mysql/mysql_user.go
+++ b/core-service/src/modules/user/repository/mysql/mysql_user.go
@@ -268,7 +268,7 @@ func (m *mysqlUserRepository) ChangeEmail(ctx context.Context, id uuid.UUID, ema
 	return
 }
 
-func (m *mysqlUserRepository) ActivateAccount(ctx context.Context, id uuid.UUID, status string) (err error) {
+func (m *mysqlUserRepository) ChangeStatus(ctx context.Context, id uuid.UUID, status string) (err error) {
 	query := `UPDATE users SET status = ? WHERE id = ?`
 	stmt, err := m.Conn.PrepareContext(ctx, query)
 	if err != nil {

--- a/core-service/src/modules/user/usecase/user_usecase.go
+++ b/core-service/src/modules/user/usecase/user_usecase.go
@@ -328,7 +328,7 @@ func (n *userUsecase) ChangeEmail(c context.Context, id uuid.UUID, req *domain.C
 	return
 }
 
-func (n *userUsecase) ActivateAccount(c context.Context, id uuid.UUID, req *domain.CheckPasswordRequest, userID uuid.UUID) (err error) {
+func (n *userUsecase) ChangeStatus(c context.Context, id uuid.UUID, req *domain.CheckPasswordRequest, userID uuid.UUID) (err error) {
 	ctx, cancel := context.WithTimeout(c, n.contextTimeout)
 	defer cancel()
 
@@ -337,7 +337,7 @@ func (n *userUsecase) ActivateAccount(c context.Context, id uuid.UUID, req *doma
 		return
 	}
 
-	err = n.userRepo.ActivateAccount(ctx, userID, req.Status)
+	err = n.userRepo.ChangeStatus(ctx, userID, req.Status)
 
 	return
 }


### PR DESCRIPTION
## Overview
fix change status permission instead of activate account

## Changes
- change permission activate-account to change-status
- change endpoint path, usecase, module function to "/users/:id/change-status"
@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: fix change status permission instead of activate account
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 