### PR TITLE
add condition when login to make sure user status is active

### DIFF
--- a/core-service/src/domain/errors.go
+++ b/core-service/src/domain/errors.go
@@ -15,6 +15,8 @@ var (
 	ErrInvalidCredentials = errors.New("Invalid credentials")
 	// ErrDuplicateNIP
 	ErrDuplicateNIP = errors.New("NIP already exists")
+	// ErrUserIsNotActive
+	ErrUserIsNotActive = errors.New("Your account is not active")
 )
 
 type ErrResponse struct {

--- a/core-service/src/modules/auth/usecase/auth_ucase.go
+++ b/core-service/src/modules/auth/usecase/auth_ucase.go
@@ -89,6 +89,10 @@ func (n *authUsecase) Login(c context.Context, req *domain.LoginRequest) (res do
 		return domain.LoginResponse{}, err
 	}
 
+	if user.Status != "ACTIVE" {
+		return domain.LoginResponse{}, domain.ErrUserIsNotActive
+	}
+
 	if bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(req.Password)) != nil {
 		return domain.LoginResponse{}, domain.ErrInvalidCredentials
 	}

--- a/core-service/src/modules/user/repository/mysql/mysql_user.go
+++ b/core-service/src/modules/user/repository/mysql/mysql_user.go
@@ -20,7 +20,7 @@ func NewMysqlUserRepository(Conn *sql.DB) domain.UserRepository {
 	return &mysqlUserRepository{Conn}
 }
 
-var querySelect = `SELECT u.id, u.name, u.username, u.email, u.photo, u.password, last_password_changed, u.nip, u.occupation,
+var querySelect = `SELECT u.id, u.name, u.username, u.email, u.photo, u.password, last_password_changed, u.status, u.nip, u.occupation,
 	u.unit_id, u.role_id, un.name as unit_name FROM users u LEFT JOIN units un ON un.id = u.unit_id WHERE 1=1`
 var querySelectUnion = `SELECT member.id, member.name, member.email, member.role_id , member.status, member.last_active, member.occupation, member.nip
 	FROM (
@@ -74,6 +74,7 @@ func (m *mysqlUserRepository) scan(ctx context.Context, query string, res *domai
 		&res.Photo,
 		&res.Password,
 		&res.LastPasswordChanged,
+		&res.Status,
 		&res.Nip,
 		&res.Occupation,
 		&res.Unit.ID,


### PR DESCRIPTION
## Overview
add condition when login to make sure user status is active

## Changes
- add scan attribute status on repo get user by email
- add domain err user is not active
- add condition to check user is already active 

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: add condition when login to make sure user status is active
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 