### PR TITLE
add check email exists from invitation table

### DIFF
--- a/core-service/src/modules/user/usecase/user_usecase.go
+++ b/core-service/src/modules/user/usecase/user_usecase.go
@@ -323,6 +323,10 @@ func (n *userUsecase) ChangeEmail(c context.Context, id uuid.UUID, req *domain.C
 		return errors.New("email already registered")
 	}
 
+	if _, _ = n.regInvitationRepo.GetByEmail(ctx, newEmail); req.NewEmail != "" {
+		return errors.New("email already registered on invitation")
+	}
+
 	err = n.userRepo.ChangeEmail(ctx, userID, newEmail)
 
 	return

--- a/core-service/src/modules/user/usecase/user_usecase.go
+++ b/core-service/src/modules/user/usecase/user_usecase.go
@@ -323,7 +323,7 @@ func (n *userUsecase) ChangeEmail(c context.Context, id uuid.UUID, req *domain.C
 		return errors.New("email already registered")
 	}
 
-	if _, _ = n.regInvitationRepo.GetByEmail(ctx, newEmail); req.NewEmail != "" {
+	if reg, _ := n.regInvitationRepo.GetByEmail(ctx, newEmail); reg.Email != "" {
 		return errors.New("email already registered on invitation")
 	}
 


### PR DESCRIPTION
## Changes
- add validation email exists from invitation table

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: add check email exists from invitation table
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 