### PR TITLE
Add new struct reporter, editor on news module

### DIFF
--- a/core-service/src/database/migrations/20220411060845_add_column_reporter_editor_on_news_table.down.sql
+++ b/core-service/src/database/migrations/20220411060845_add_column_reporter_editor_on_news_table.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE news 
+    DROP COLUMN reporter,
+    DROP COLUMN editor;

--- a/core-service/src/database/migrations/20220411060845_add_column_reporter_editor_on_news_table.up.sql
+++ b/core-service/src/database/migrations/20220411060845_add_column_reporter_editor_on_news_table.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE news RENAME COLUMN author_id TO author;
+ALTER TABLE news
+    ADD COLUMN reporter VARCHAR(36) NULL AFTER author,
+    ADD COLUMN editor VARCHAR (36) NULL AFTER reporter;

--- a/core-service/src/domain/news.go
+++ b/core-service/src/domain/news.go
@@ -22,7 +22,9 @@ type News struct {
 	Type        string     `json:"type"`
 	Tags        []DataTag  `json:"tags"`
 	Category    string     `json:"category" validate:"required"`
-	Author      User       `json:"author" validate:"required"`
+	Author      *string    `json:"author" validate:"required"`
+	Reporter    *string    `json:"reporter"`
+	Editor      *string    `json:"editor"`
 	Area        Area       `json:"area" validate:"required"`
 	Duration    int8       `json:"duration"`
 	StartDate   NullTime   `json:"start_date"`
@@ -47,7 +49,9 @@ type StoreNewsRequest struct {
 	Status      string     `json:"status" validate:"required,eq=DRAFT|eq=REVIEW|eq=PUBLISHED|eq=ARCHIVED"`
 	Type        string     `json:"type"`
 	Category    string     `json:"category"`
-	Author      User       `json:"author"`
+	Author      string     `json:"author"`
+	Reporter    string     `json:"reporter"`
+	Editor      string     `json:"editor"`
 	Duration    int8       `json:"duration"`
 	StartDate   *string    `json:"start_date"`
 	EndDate     *string    `json:"end_date"`
@@ -74,13 +78,15 @@ type NewsListResponse struct {
 	Slug        NullString `json:"slug"`
 	Image       *string    `json:"image"`
 	Category    string     `json:"category"`
-	Author      Author     `json:"author"`
+	Author      string     `json:"author"`
+	Reporter    string     `json:"reporter"`
+	Editor      string     `json:"editor"`
 	Video       NullString `json:"video"`
 	Source      NullString `json:"source"`
 	Tags        []DataTag  `json:"tags"`
 	Status      string     `json:"status"`
 	IsLive      int8       `json:"is_live"`
-	CreatedBy   NullString `json:"created_by"`
+	CreatedBy   Author     `json:"created_by"`
 	PublishedAt *time.Time `json:"published_at"`
 	CreatedAt   time.Time  `json:"created_at"`
 	UpdatedAt   time.Time  `json:"updated_at"`
@@ -93,7 +99,7 @@ type NewsBanner struct {
 	Category    string       `json:"category"`
 	Image       *string      `json:"image"`
 	Slug        NullString   `json:"slug"`
-	Author      Author       `json:"author,omitempty"`
+	CreatedBy   Author       `json:"created_by,omitempty"`
 	CreatedAt   time.Time    `json:"created_at"`
 	PublishedAt *time.Time   `json:"published_at"`
 	RelatedNews []NewsBanner `json:"related_news,omitempty"`
@@ -116,12 +122,15 @@ type DetailNewsResponse struct {
 	Type        string           `json:"type"`
 	Tags        []DataTag        `json:"tags"`
 	Category    string           `json:"category"`
-	Author      Author           `json:"author"`
+	Author      string           `json:"author"`
+	Reporter    string           `json:"reporter"`
+	Editor      string           `json:"editor"`
 	Duration    int8             `json:"duration"`
 	StartDate   NullTime         `json:"start_date"`
 	EndDate     NullTime         `json:"end_date"`
 	Area        AreaListResponse `json:"area"`
 	PublishedAt time.Time        `json:"published_at"`
+	CreatedBy   Author           `json:"created_by"`
 	CreatedAt   time.Time        `json:"created_at"`
 	UpdatedAt   time.Time        `json:"updated_at"`
 }

--- a/core-service/src/modules/news/delivery/http/news_handler.go
+++ b/core-service/src/modules/news/delivery/http/news_handler.go
@@ -214,8 +214,8 @@ func (h *NewsHandler) Store(c echo.Context) (err error) {
 	auth := domain.JwtCustomClaims{}
 	mapstructure.Decode(c.Get("auth:user"), &auth)
 
-	n.Author.ID = auth.ID
-	n.Author.Name = auth.Name
+	n.CreatedBy.ID = auth.ID
+	n.CreatedBy.Name = auth.Name
 
 	ctx := c.Request().Context()
 	err = h.CUsecase.Store(ctx, n)
@@ -251,8 +251,8 @@ func (h *NewsHandler) Update(c echo.Context) (err error) {
 	auth := domain.JwtCustomClaims{}
 	mapstructure.Decode(c.Get("auth:user"), &auth)
 
-	n.Author.ID = auth.ID
-	n.Author.Name = auth.Name
+	n.CreatedBy.ID = auth.ID
+	n.CreatedBy.Name = auth.Name
 
 	ctx := c.Request().Context()
 	err = h.CUsecase.Update(ctx, int64(reqID), n)

--- a/core-service/src/modules/news/repository/mysql/mysql_news_test.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news_test.go
@@ -46,13 +46,13 @@ func TestFetch(t *testing.T) {
 		},
 	}
 
-	rows := sqlmock.NewRows([]string{"id", "category", "title", "excerpt", "content", "image", "video", "slug", "author_id", "area_id", "type", "views", "shared", "source", "duration", "start_date", "end_date", "status", "is_live", "published_at", "created_at", "updated_at"}).
+	rows := sqlmock.NewRows([]string{"id", "category", "title", "excerpt", "content", "image", "video", "slug", "author", "reporter", "editor", "area_id", "type", "views", "shared", "source", "duration", "start_date", "end_date", "status", "is_live", "published_at", "created_by", "created_at", "updated_at"}).
 		AddRow(mockNews[0].ID, mockNews[0].Category, mockNews[0].Title, mockNews[0].Excerpt, mockNews[0].Content,
-			nil, nil, mockNews[0].Slug, "", 0, "", mockNews[0].Views, mockNews[0].Shared, mockNews[0].Source.String, 0, mockNews[0].StartDate.Time, mockNews[0].EndDate.Time, mockNews[0].Status, 0, mockNews[0].PublishedAt, mockNews[0].CreatedAt, mockNews[0].UpdatedAt).
+			nil, nil, mockNews[0].Slug, "", "", "", 0, "", mockNews[0].Views, mockNews[0].Shared, mockNews[0].Source.String, 0, mockNews[0].StartDate.Time, mockNews[0].EndDate.Time, mockNews[0].Status, 0, mockNews[0].PublishedAt, nil, mockNews[0].CreatedAt, mockNews[0].UpdatedAt).
 		AddRow(mockNews[1].ID, mockNews[1].Category, mockNews[1].Title, mockNews[1].Excerpt, mockNews[1].Content,
-			nil, nil, mockNews[1].Slug, "", 0, "", mockNews[1].Views, mockNews[1].Shared, mockNews[1].Source.String, 0, mockNews[1].StartDate.Time, mockNews[1].EndDate.Time, mockNews[1].Status, 0, mockNews[1].PublishedAt, mockNews[1].CreatedAt, mockNews[1].UpdatedAt)
+			nil, nil, mockNews[1].Slug, "", "", "", 0, "", mockNews[1].Views, mockNews[1].Shared, mockNews[1].Source.String, 0, mockNews[1].StartDate.Time, mockNews[1].EndDate.Time, mockNews[1].Status, 0, mockNews[1].PublishedAt, nil, mockNews[1].CreatedAt, mockNews[1].UpdatedAt)
 
-	query := "SELECT n.id, n.category, n.title, n.excerpt, n.content, n.image, n.video, n.slug, n.author_id, n.area_id, n.type, n.views, n.shared, n.source, n.duration, n.start_date, n.end_date, n.status, n.is_live, n.published_at, n.created_at, n.updated_at FROM news n LEFT JOIN users u ON n.author_id = u.id WHERE n.deleted_at is NULL"
+	query := "SELECT n.id, n.category, n.title, n.excerpt, n.content, n.image, n.video, n.slug, n.author, n.reporter, n.editor, n.area_id, n.type, n.views, n.shared, n.source, n.duration, n.start_date, n.end_date, n.status, n.is_live, n.published_at, n.created_by, n.created_at, n.updated_at FROM news n LEFT JOIN users u ON n.created_by = u.id WHERE n.deleted_at is NULL"
 
 	mock.ExpectQuery(query).WillReturnRows(rows)
 	a := mysqlRepo.NewMysqlNewsRepository(db)

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -131,14 +131,14 @@ func (n *newsUsecase) fillDataTagsDetail(c context.Context, data domain.News) (d
 	return data, nil
 }
 
-func (n *newsUsecase) fillAuthorDetails(c context.Context, data []domain.News) ([]domain.News, error) {
+func (n *newsUsecase) fillUserDetails(c context.Context, data []domain.News) ([]domain.News, error) {
 	g, ctx := errgroup.WithContext(c)
 
 	// Get the user's id
 	mapUsers := map[uuid.UUID]domain.User{}
 
 	for _, news := range data {
-		mapUsers[news.Author.ID] = domain.User{}
+		mapUsers[news.CreatedBy.ID] = domain.User{}
 	}
 
 	// Using goroutine to fetch the user's detail
@@ -176,8 +176,8 @@ func (n *newsUsecase) fillAuthorDetails(c context.Context, data []domain.News) (
 
 	// merge the user's data
 	for index, item := range data {
-		if a, ok := mapUsers[item.Author.ID]; ok {
-			data[index].Author = a
+		if a, ok := mapUsers[item.CreatedBy.ID]; ok {
+			data[index].CreatedBy = a
 		}
 	}
 
@@ -253,11 +253,11 @@ func (n *newsUsecase) getDetail(ctx context.Context, key string, value interface
 		return
 	}
 
-	resAuthor, err := n.userRepo.GetByID(ctx, res.Author.ID)
+	resCreatedBy, err := n.userRepo.GetByID(ctx, res.CreatedBy.ID)
 	if err != nil {
 		return
 	}
-	res.Author = resAuthor
+	res.CreatedBy = resCreatedBy
 
 	res, err = n.fillDataTagsDetail(ctx, res)
 
@@ -324,7 +324,7 @@ func (n *newsUsecase) Fetch(c context.Context, params *domain.Request) (res []do
 		return nil, 0, err
 	}
 
-	res, err = n.fillAuthorDetails(ctx, res)
+	res, err = n.fillUserDetails(ctx, res)
 
 	if err != nil {
 		return nil, 0, err
@@ -374,7 +374,7 @@ func (n *newsUsecase) FetchNewsBanner(c context.Context) (res []domain.NewsBanne
 		return nil, err
 	}
 
-	news, err = n.fillAuthorDetails(ctx, news)
+	news, err = n.fillUserDetails(ctx, news)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +399,7 @@ func (n *newsUsecase) FetchNewsHeadline(c context.Context) (res []domain.News, e
 		return nil, err
 	}
 
-	res, err = n.fillAuthorDetails(ctx, res)
+	res, err = n.fillUserDetails(ctx, res)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Overview
Add new struct reporter, editor on news module

## Changes
- add new migration to change **author_id** to **author**, also add new column **reporter** and **editor**
- putting of author object instead of created by object
- adjust response to add author, reporter, editor as a string
- adjust related endpoint (store, update, fetch, getbyid, newsbanner)

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: Add new struct reporter, editor on news module
participants: @rachadiannovansyah @khihadysucahyo 