### PR TITLE
fix counting tabs status news role contributor

### DIFF
--- a/core-service/src/domain/news.go
+++ b/core-service/src/domain/news.go
@@ -3,6 +3,8 @@ package domain
 import (
 	"context"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // News ...
@@ -152,7 +154,7 @@ type NewsUsecase interface {
 	Store(context.Context, *StoreNewsRequest) error
 	Update(context.Context, int64, *StoreNewsRequest) error
 	UpdateStatus(context.Context, int64, string) error
-	TabStatus(context.Context) ([]TabStatusResponse, error)
+	TabStatus(context.Context, *JwtCustomClaims) ([]TabStatusResponse, error)
 	Delete(ctx context.Context, id int64) error
 }
 
@@ -167,6 +169,6 @@ type NewsRepository interface {
 	AddShare(ctx context.Context, id int64) (err error)
 	Store(ctx context.Context, n *StoreNewsRequest) error
 	Update(ctx context.Context, id int64, n *StoreNewsRequest) error
-	TabStatus(ctx context.Context) (res []TabStatusResponse, err error)
+	TabStatus(ctx context.Context, id uuid.UUID, key string) (res []TabStatusResponse, err error)
 	Delete(ctx context.Context, id int64) error
 }

--- a/core-service/src/modules/news/delivery/http/news_handler.go
+++ b/core-service/src/modules/news/delivery/http/news_handler.go
@@ -42,8 +42,8 @@ func NewNewsHandler(e *echo.Group, r *echo.Group, us domain.NewsUsecase) {
 	r.PUT("/news/:id", handler.Update, middl.CheckPermission(permManageNews))
 	r.DELETE("/news/:id", handler.Delete, middl.CheckPermission(permManageNews))
 	r.PATCH("/news/:id/status", handler.UpdateStatus) // TO DO permission update status has multiple values
-	e.GET("/news/slug/:slug", handler.GetBySlug)      // to be removed after frontend is ready
-	e.GET("/news/tabs", handler.TabStatus)
+	r.GET("/news/tabs", handler.TabStatus)
+	e.GET("/news/slug/:slug", handler.GetBySlug)       // to be removed after frontend is ready
 	e.GET("/news/banner", handler.FetchNewsBanner)     // to be removed after frontend is ready
 	e.GET("/news/headline", handler.FetchNewsHeadline) // to be removed after frontend is ready
 	e.PATCH("/news/:id/share", handler.AddShare)       // to be removed after frontend is ready
@@ -147,8 +147,12 @@ func (h *NewsHandler) GetByID(c echo.Context) error {
 
 func (h *NewsHandler) TabStatus(c echo.Context) (err error) {
 	ctx := c.Request().Context()
+	au := helpers.GetAuthenticatedUser(c)
 
-	tabs, err := h.CUsecase.TabStatus(ctx)
+	tabs, err := h.CUsecase.TabStatus(ctx, au)
+	if err != nil {
+		return
+	}
 
 	return c.JSON(http.StatusOK, &domain.ResultData{Data: &tabs})
 }

--- a/core-service/src/modules/news/repository/mysql/mysql_news.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news.go
@@ -107,10 +107,17 @@ func (m *mysqlNewsRepository) findOne(ctx context.Context, key string, value str
 	return
 }
 
-func (m *mysqlNewsRepository) TabStatus(ctx context.Context) (res []domain.TabStatusResponse, err error) {
-	query := "SELECT status, COUNT(status) FROM news GROUP BY status"
+func (m *mysqlNewsRepository) TabStatus(ctx context.Context, id uuid.UUID, key string) (res []domain.TabStatusResponse, err error) {
+	var query string
+	var list []domain.TabStatusResponse
 
-	list, err := m.fetchTabs(ctx, query)
+	if key == "contributor" {
+		query = "SELECT status, COUNT(status) FROM news WHERE created_by = ? GROUP BY status"
+		list, err = m.fetchTabs(ctx, query, id)
+	} else {
+		query = "SELECT status, COUNT(status) FROM news GROUP BY status"
+		list, err = m.fetchTabs(ctx, query)
+	}
 
 	if err != nil {
 		return []domain.TabStatusResponse{}, err

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -271,8 +271,12 @@ func (n *newsUsecase) getDetail(ctx context.Context, key string, value interface
 	return
 }
 
-func (n *newsUsecase) TabStatus(ctx context.Context) (res []domain.TabStatusResponse, err error) {
-	res, err = n.newsRepo.TabStatus(ctx)
+func (n *newsUsecase) TabStatus(ctx context.Context, au *domain.JwtCustomClaims) (res []domain.TabStatusResponse, err error) {
+	var key string
+	if au.Role.ID == domain.RoleContributor {
+		key = "contributor"
+	}
+	res, err = n.newsRepo.TabStatus(ctx, au.ID, key)
 
 	if err != nil {
 		return


### PR DESCRIPTION
## Overview
Fix counting tabs status news role contributor

## Changes
- add condition when contributor role only show his own tabs count news with their id

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: fix counting tabs status news role contributor
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 