### PR TITLE
add trim to fix over length tags

### DIFF
--- a/core-service/src/modules/event/usecase/event_ucase.go
+++ b/core-service/src/modules/event/usecase/event_ucase.go
@@ -137,7 +137,7 @@ func (u *eventUcase) fillDetailDataTags(c context.Context, data domain.Event) (d
 func (u *eventUcase) storeTags(ctx context.Context, eventID int64, tags []string) (err error) {
 	for _, tagName := range tags {
 		tag := &domain.Tag{
-			Name: tagName,
+			Name: tagName[:20],
 		}
 
 		// check tags already exists
@@ -154,7 +154,7 @@ func (u *eventUcase) storeTags(ctx context.Context, eventID int64, tags []string
 		dataTag := &domain.DataTag{
 			DataID:  eventID,
 			TagID:   tag.ID,
-			TagName: tagName,
+			TagName: tagName[:20],
 			Type:    "event",
 		}
 		err = u.dataTagRepo.StoreDataTag(ctx, dataTag)

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -289,7 +289,7 @@ func (n *newsUsecase) storeTags(ctx context.Context, newsId int64, tags []string
 
 	for _, tagName := range tags {
 		tag := &domain.Tag{
-			Name: tagName,
+			Name: tagName[:20],
 		}
 
 		// check tags already exists
@@ -306,7 +306,7 @@ func (n *newsUsecase) storeTags(ctx context.Context, newsId int64, tags []string
 		dataTag := &domain.DataTag{
 			DataID:  newsId,
 			TagID:   tag.ID,
-			TagName: tagName,
+			TagName: tagName[:20],
 			Type:    "news",
 		}
 		err = n.dataTagRepo.StoreDataTag(ctx, dataTag)


### PR DESCRIPTION
Fix issue ticket:
- Add trim tags to avoid over length on input tags

Evidence:
project: Portal Jabar
title: Add trim tags to avoid over length on input tags
participants: @rachadiannovansyah @khihadysucahyo 