### PR TITLE
add policy authorized user on api detail event

### DIFF
--- a/core-service/src/policies/event_policy.go
+++ b/core-service/src/policies/event_policy.go
@@ -1,0 +1,14 @@
+package policies
+
+import (
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
+)
+
+func AllowEventAccess(au *domain.JwtCustomClaims, e domain.Event) bool {
+	if !helpers.IsSuperAdmin(au) {
+		return au.Unit.Name.String == e.CreatedBy.UnitName
+	}
+
+	return false
+}


### PR DESCRIPTION
## Overview
mitigate unauthorized user access endpoint detail

## Changes
- add policy authorized user on endpoint detail agenda

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: add policy authorized user on event
participants: @rachadiannovansyah @khihadysucahyo 