### PR TITLE
allow string/slice on category filter

### DIFF
--- a/core-service/src/modules/news/delivery/http/public_news_handler.go
+++ b/core-service/src/modules/news/delivery/http/public_news_handler.go
@@ -33,6 +33,7 @@ func (h *PublicNewsHandler) FetchNews(c echo.Context) error {
 
 	params := helpers.GetRequestParams(c)
 	params.Filters = map[string]interface{}{
+		"category":   c.QueryParam("cat"),
 		"categories": c.Request().URL.Query()["cat[]"],
 		"highlight":  c.QueryParam("highlight"),
 		"type":       c.QueryParam("type"),

--- a/core-service/src/modules/news/repository/mysql/mysql_news_helper.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news_helper.go
@@ -42,7 +42,9 @@ func filterNewsQuery(params *domain.Request) string {
 		query = fmt.Sprintf(`%s AND n.status = "%s"`, query, v)
 	}
 
-	if v, ok := params.Filters["categories"]; ok && v != "" {
+	if v, ok := params.Filters["category"]; ok && v != "" {
+		query = fmt.Sprintf(`%s AND n.category = '%s'`, query, v)
+	} else if v, ok := params.Filters["categories"]; ok && v != "" {
 		categories := params.Filters["categories"].([]string)
 
 		if len(categories) > 0 {


### PR DESCRIPTION
@jabardigitalservice/jds-backend 

seems like portal use singular `cat` param instead of `cat[]` ,  during prod preparation and maybe takes time to have some context switching to fixing this bug, I propose this category filter to be able filter as string or slice