### PR TITLE
add excerpt on engine migrater to sync data public service

### DIFF
--- a/core-service/src/cmd/migrater/main.go
+++ b/core-service/src/cmd/migrater/main.go
@@ -427,11 +427,18 @@ func DoSyncElasticPublicService(cfg *config.Config, command string) error {
 			//format time
 			layout := "2006-01-02 15:04:05"
 
+			var excerpt string
+			description := data.Description.String
+			forExcerptLength := 160
+			if len(description) > forExcerptLength {
+				excerpt = description[:forExcerptLength]
+			}
+
 			b.WriteString(fmt.Sprintf(`{"id" : %v,`, data.ID))
 			b.WriteString(fmt.Sprintf(`"domain" : "%v",`, "public_service"))
 			b.WriteString(fmt.Sprintf(`"title" : "%v",`, data.Name))
-			b.WriteString(fmt.Sprintf(`"excerpt" : "%v",`, ""))
-			b.WriteString(fmt.Sprintf(`"content" : "%v",`, data.Description.String))
+			b.WriteString(fmt.Sprintf(`"excerpt" : "%v",`, excerpt))
+			b.WriteString(fmt.Sprintf(`"content" : "%v",`, description))
 			b.WriteString(fmt.Sprintf(`"unit" : "%v",`, data.Unit.String))
 			b.WriteString(fmt.Sprintf(`"url" : "%v",`, data.Url.String))
 			b.WriteString(fmt.Sprintf(`"slug" : "%v",`, ""))

--- a/core-service/src/modules/user/repository/mysql/mysql_user.go
+++ b/core-service/src/modules/user/repository/mysql/mysql_user.go
@@ -20,7 +20,7 @@ func NewMysqlUserRepository(Conn *sql.DB) domain.UserRepository {
 	return &mysqlUserRepository{Conn}
 }
 
-var querySelect = `SELECT u.id, u.name, u.username, u.email, u.photo, u.password, last_password_changed, u.status, u.nip, u.occupation,
+var querySelect = `SELECT u.id, u.name, u.username, u.email, u.photo, u.password, last_password_changed, u.last_active, u.status, u.nip, u.occupation,
 	u.unit_id, u.role_id, un.name as unit_name FROM users u LEFT JOIN units un ON un.id = u.unit_id WHERE 1=1`
 var querySelectUnion = `SELECT member.id, member.name, member.email, member.role_id , member.status, member.last_active, member.occupation, member.nip
 	FROM (
@@ -74,6 +74,7 @@ func (m *mysqlUserRepository) scan(ctx context.Context, query string, res *domai
 		&res.Photo,
 		&res.Password,
 		&res.LastPasswordChanged,
+		&res.LastActive,
 		&res.Status,
 		&res.Nip,
 		&res.Occupation,


### PR DESCRIPTION
## Overview
- add excerpt on engine migrater to sync data public service
- add user last active on detail user

@jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: menambahkan excerpt pada migrater public service elastic
participants: @rachadiannovansyah @khihadysucahyo @ayocodingit 