### PR TITLE
fix archived news is still active on elastic database

### DIFF
--- a/core-service/src/cmd/migrater/main.go
+++ b/core-service/src/cmd/migrater/main.go
@@ -235,7 +235,6 @@ func DoSyncElastic(cfg *config.Config, command string) error {
 			b.WriteString(fmt.Sprintf(`"updated_at" : "%s",`, data.UpdatedAt.Format(layout)))
 			b.WriteString(fmt.Sprintf(`"thumbnail" : "%v",`, *data.Image))
 			b.WriteString(fmt.Sprintf(`"is_active" : %v}`, data.IsLive == 1))
-			//fmt.Println(b.String())
 
 			// Set up the request object.
 			req := esapi.IndexRequest{
@@ -338,7 +337,6 @@ func DoSyncElasticFeaturedProgram(cfg *config.Config, command string) error {
 			b.WriteString(fmt.Sprintf(`"updated_at" : "%s",`, data.UpdatedAt.Format(layout)))
 			b.WriteString(fmt.Sprintf(`"thumbnail" : "%v",`, data.Logo.String))
 			b.WriteString(fmt.Sprintf(`"is_active" : %v}`, true))
-			// fmt.Println(b.String())
 
 			// Set up the request object.
 			req := esapi.IndexRequest{
@@ -365,8 +363,6 @@ func DoSyncElasticFeaturedProgram(cfg *config.Config, command string) error {
 					log.Printf("Error parsing the response body: %s", err)
 				} else {
 					// Print the response status and indexed document version.
-					// fmt.Println(b.String())
-
 					log.Printf("[%s] %s; version=%d", res.Status(), r["result"], int(r["_version"].(float64)))
 				}
 			}
@@ -390,7 +386,7 @@ func DoSyncElasticPublicService(cfg *config.Config, command string) error {
 
 	// 1. Get cluster info
 	res, err := es.Info()
-	// fmt.Println("THIS IS RES", res, err)
+
 	if err != nil {
 		logrus.Fatalf("Error getting response: %s", err)
 	}

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -537,6 +537,8 @@ func (n *newsUsecase) UpdateStatus(c context.Context, id int64, status string) (
 	if status == "PUBLISHED" {
 		newsRequest.Slug = helpers.MakeSlug(newsRequest.Title, newsRequest.ID)
 		helpers.SetPropLiveNews(&newsRequest)
+	} else if status == "ARCHIVED" {
+		news.IsLive = 0
 	}
 
 	err = n.newsRepo.Update(ctx, id, &newsRequest)


### PR DESCRIPTION
## Overview
- fix **_archived_** news is still active on elastic database
- remove unused code

cc: @jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: fixing berita yang sudah di arsip masih muncul pada global search
participants: @rachadiannovansyah 