### PR TITLE
add filter tag news based on domain data tag

### DIFF
--- a/core-service/src/go.mod
+++ b/core-service/src/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gosimple/slug v1.12.0
 	github.com/jinzhu/copier v0.3.2
+	github.com/kr/pretty v0.2.1 // indirect
 	github.com/labstack/echo/v4 v4.5.0
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.1

--- a/core-service/src/modules/data-tag/repository/mysql/mysql_data_tag.go
+++ b/core-service/src/modules/data-tag/repository/mysql/mysql_data_tag.go
@@ -55,6 +55,8 @@ func (m *mysqlDataTagRepository) fetch(ctx context.Context, query string, args .
 func (m *mysqlDataTagRepository) FetchDataTags(ctx context.Context, id int64, domain string) (res []domain.DataTag, err error) {
 	query := `SELECT id, data_id, tag_id, tag_name, type FROM data_tags WHERE data_id = ? AND type = ?`
 
+	// TO DO
+	// Create filter data tag based on tags name parameter
 	res, err = m.fetch(ctx, query, id, domain)
 	if err != nil {
 		return nil, err

--- a/core-service/src/modules/news/delivery/http/public_news_handler.go
+++ b/core-service/src/modules/news/delivery/http/public_news_handler.go
@@ -37,7 +37,7 @@ func (h *PublicNewsHandler) FetchNews(c echo.Context) error {
 		"categories": c.Request().URL.Query()["cat[]"],
 		"highlight":  c.QueryParam("highlight"),
 		"type":       c.QueryParam("type"),
-		"tags":       c.QueryParam("tags"),
+		"tag":        c.QueryParam("tag"),
 		"status":     c.QueryParam("status"),
 		"exclude":    c.QueryParam("exclude"),
 	}

--- a/core-service/src/modules/news/repository/mysql/mysql_news_helper.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news_helper.go
@@ -46,7 +46,7 @@ func filterNewsQuery(params *domain.Request) string {
 		query = fmt.Sprintf(`%s AND n.id <> "%s"`, query, v)
 	}
 
-	if v, ok := params.Filters["tags"]; ok && v != "" {
+	if v, ok := params.Filters["tag"]; ok && v != "" {
 		query = fmt.Sprintf(`%s AND n.id IN (SELECT data_id FROM data_tags WHERE tag_name = '%s')`, query, v)
 	}
 

--- a/core-service/src/modules/news/repository/mysql/mysql_news_helper.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news_helper.go
@@ -46,6 +46,10 @@ func filterNewsQuery(params *domain.Request) string {
 		query = fmt.Sprintf(`%s AND n.id <> "%s"`, query, v)
 	}
 
+	if v, ok := params.Filters["tags"]; ok && v != "" {
+		query = fmt.Sprintf(`%s AND n.id IN (SELECT data_id FROM data_tags WHERE tag_name = '%s')`, query, v)
+	}
+
 	if v, ok := params.Filters["category"]; ok && v != "" {
 		query = fmt.Sprintf(`%s AND n.category = '%s'`, query, v)
 	} else if v, ok := params.Filters["categories"]; ok && v != "" {


### PR DESCRIPTION
## Overview
now can filter news by tags from data tag domain

cc: @jabardigitalservice/jds-backend 

## Evidence
project: Portal Jabar
title: menambahkan filter berita berdasarkan tags 
participants: @rachadiannovansyah @indraprasetya154 @sandisunandar99 