### PR TITLE
Sync published at on news elastic

### DIFF
--- a/core-service/src/domain/search.go
+++ b/core-service/src/domain/search.go
@@ -7,21 +7,21 @@ import (
 
 // Search ...
 type Search struct {
-	ID          int       `json:"id"`
-	Domain      string    `json:"domain"`
-	Title       string    `json:"title"`
-	Excerpt     string    `json:"excerpt"`
-	Content     string    `json:"content"`
-	Slug        string    `json:"slug"`
-	Category    string    `json:"category"`
-	Thumbnail   string    `json:"thumbnail"`
-	Unit        string    `json:"unit"`
-	Url         string    `json:"url"`
-	Highlight   []string  `json:"highlight"`
-	PublishedAt time.Time `json:"published_at"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
-	IsActive    bool      `json:"is_active"`
+	ID          int        `json:"id"`
+	Domain      string     `json:"domain"`
+	Title       string     `json:"title"`
+	Excerpt     string     `json:"excerpt"`
+	Content     string     `json:"content"`
+	Slug        string     `json:"slug"`
+	Category    string     `json:"category"`
+	Thumbnail   string     `json:"thumbnail"`
+	Unit        string     `json:"unit"`
+	Url         string     `json:"url"`
+	Highlight   []string   `json:"highlight"`
+	PublishedAt *time.Time `json:"published_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	IsActive    bool       `json:"is_active"`
 }
 
 // SearchListResponse ...
@@ -37,7 +37,7 @@ type SearchListResponse struct {
 	Unit        string      `json:"unit"`
 	Url         string      `json:"url"`
 	Highlight   interface{} `json:"highlight"`
-	PublishedAt time.Time   `json:"published_at"`
+	PublishedAt *time.Time  `json:"published_at"`
 	CreatedAt   time.Time   `json:"created_at" mapstructure:"created_at"`
 }
 

--- a/core-service/src/domain/search.go
+++ b/core-service/src/domain/search.go
@@ -7,36 +7,38 @@ import (
 
 // Search ...
 type Search struct {
-	ID        int       `json:"id"`
-	Domain    string    `json:"domain"`
-	Title     string    `json:"title"`
-	Excerpt   string    `json:"excerpt"`
-	Content   string    `json:"content"`
-	Slug      string    `json:"slug"`
-	Category  string    `json:"category"`
-	Thumbnail string    `json:"thumbnail"`
-	Unit      string    `json:"unit"`
-	Url       string    `json:"url"`
-	Highlight []string  `json:"highlight"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	IsActive  bool      `json:"is_active"`
+	ID          int       `json:"id"`
+	Domain      string    `json:"domain"`
+	Title       string    `json:"title"`
+	Excerpt     string    `json:"excerpt"`
+	Content     string    `json:"content"`
+	Slug        string    `json:"slug"`
+	Category    string    `json:"category"`
+	Thumbnail   string    `json:"thumbnail"`
+	Unit        string    `json:"unit"`
+	Url         string    `json:"url"`
+	Highlight   []string  `json:"highlight"`
+	PublishedAt time.Time `json:"published_at"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	IsActive    bool      `json:"is_active"`
 }
 
 // SearchListResponse ...
 type SearchListResponse struct {
-	ID        int         `json:"id"`
-	Domain    string      `json:"domain"`
-	Title     string      `json:"title"`
-	Excerpt   string      `json:"excerpt"`
-	Content   string      `json:"content"`
-	Slug      string      `json:"slug"`
-	Category  string      `json:"category"`
-	Thumbnail string      `json:"thumbnail"`
-	Unit      string      `json:"unit"`
-	Url       string      `json:"url"`
-	Highlight interface{} `json:"highlight"`
-	CreatedAt time.Time   `json:"created_at" mapstructure:"created_at"`
+	ID          int         `json:"id"`
+	Domain      string      `json:"domain"`
+	Title       string      `json:"title"`
+	Excerpt     string      `json:"excerpt"`
+	Content     string      `json:"content"`
+	Slug        string      `json:"slug"`
+	Category    string      `json:"category"`
+	Thumbnail   string      `json:"thumbnail"`
+	Unit        string      `json:"unit"`
+	Url         string      `json:"url"`
+	Highlight   interface{} `json:"highlight"`
+	PublishedAt time.Time   `json:"published_at"`
+	CreatedAt   time.Time   `json:"created_at" mapstructure:"created_at"`
 }
 
 // SuggestResponse ..

--- a/core-service/src/helpers/elastic.go
+++ b/core-service/src/helpers/elastic.go
@@ -11,3 +11,9 @@ func ParseESDate(strDateTime string) time.Time {
 	tCreatedAt, _ := time.Parse(tLayout, strDateTime)
 	return tCreatedAt
 }
+
+func ParseESPointerDate(strDateTime string) *time.Time {
+	tLayout := "2006-01-02 15:04:05" // timestamp layout
+	tPublishedAt, _ := time.Parse(tLayout, strDateTime)
+	return &tPublishedAt
+}

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -463,19 +463,24 @@ func (n *newsUsecase) Store(c context.Context, dt *domain.StoreNewsRequest) (err
 		return
 	}
 
+	if dt.Status == "REVIEW" {
+		dt.PublishedAt = &time.Time{}
+	}
+
 	// FIXME: make a function to prepare data for search index
 	err = n.searchRepo.Store(ctx, n.cfg.ELastic.IndexContent, &domain.Search{
-		ID:        int(dt.ID),
-		Domain:    "news",
-		Title:     dt.Title,
-		Excerpt:   dt.Excerpt,
-		Content:   dt.Content,
-		Slug:      dt.Slug,
-		Category:  dt.Category,
-		Thumbnail: *dt.Image,
-		CreatedAt: dt.CreatedAt,
-		UpdatedAt: dt.UpdatedAt,
-		IsActive:  dt.IsLive == 1,
+		ID:          int(dt.ID),
+		Domain:      "news",
+		Title:       dt.Title,
+		Excerpt:     dt.Excerpt,
+		Content:     dt.Content,
+		Slug:        dt.Slug,
+		Category:    dt.Category,
+		Thumbnail:   *dt.Image,
+		PublishedAt: *dt.PublishedAt,
+		CreatedAt:   dt.CreatedAt,
+		UpdatedAt:   dt.UpdatedAt,
+		IsActive:    dt.IsLive == 1,
 	})
 
 	return

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -477,7 +477,7 @@ func (n *newsUsecase) Store(c context.Context, dt *domain.StoreNewsRequest) (err
 		Slug:        dt.Slug,
 		Category:    dt.Category,
 		Thumbnail:   *dt.Image,
-		PublishedAt: *dt.PublishedAt,
+		PublishedAt: dt.PublishedAt,
 		CreatedAt:   dt.CreatedAt,
 		UpdatedAt:   dt.UpdatedAt,
 		IsActive:    dt.IsLive == 1,

--- a/core-service/src/modules/search/repository/elastic/elastic_search.go
+++ b/core-service/src/modules/search/repository/elastic/elastic_search.go
@@ -77,7 +77,7 @@ func buildQuery(params *domain.Request) (buf bytes.Buffer) {
 
 	query := q{
 		"_source": q{
-			"includes": []string{"id", "domain", "title", "excerpt", "slug", "category", "thumbnail", "content", "unit", "url", "created_at"},
+			"includes": []string{"id", "domain", "title", "excerpt", "slug", "category", "thumbnail", "content", "unit", "url", "published_at", "created_at"},
 		},
 		"sort": []map[string]interface{}{
 			paramsSort,
@@ -234,17 +234,18 @@ func (es *elasticSearchRepository) Store(ctx context.Context, indices string, da
 
 	// prepare the data to be indexed
 	doc := q{
-		"id":         data.ID,
-		"domain":     data.Domain,
-		"title":      data.Title,
-		"excerpt":    data.Excerpt,
-		"content":    content,
-		"slug":       data.Slug,
-		"category":   data.Category,
-		"thumbnail":  data.Thumbnail,
-		"created_at": data.CreatedAt.Format(formatTime),
-		"updated_at": data.UpdatedAt.Format(formatTime),
-		"is_active":  data.IsActive,
+		"id":           data.ID,
+		"domain":       data.Domain,
+		"title":        data.Title,
+		"excerpt":      data.Excerpt,
+		"content":      content,
+		"slug":         data.Slug,
+		"category":     data.Category,
+		"thumbnail":    data.Thumbnail,
+		"published_at": data.PublishedAt.Format(formatTime),
+		"created_at":   data.CreatedAt.Format(formatTime),
+		"updated_at":   data.UpdatedAt.Format(formatTime),
+		"is_active":    data.IsActive,
 	}
 
 	jsonString, err := json.Marshal(doc)

--- a/core-service/src/modules/search/repository/elastic/elastic_search.go
+++ b/core-service/src/modules/search/repository/elastic/elastic_search.go
@@ -52,6 +52,9 @@ func mapElasticDocs(mapResp map[string]interface{}) (res []domain.SearchListResp
 		mapstructure.Decode(source, &searchData)
 
 		// parsing the date string to time.Time
+		if _, ok := source["published_at"]; ok {
+			searchData.PublishedAt = helpers.ParseESPointerDate(source["published_at"].(string))
+		}
 		searchData.CreatedAt = helpers.ParseESDate(source["created_at"].(string))
 		searchData.Highlight = highlight
 


### PR DESCRIPTION
Overview
Add attribute **published_at** value on global search 

- adjust use case news
- adjust elastic repo
- use *time.Time to mitigate NullTime value

cc: https://github.com/orgs/jabardigitalservice/teams/jds-backend

Evidence
project: Portal Jabar
title: enchancement global search terkait published berita
participants: @rachadiannovansyah @sandisunandar99 @tukangremot @rindibudiaramdhan @indraprasetya154 @Ibwedagama @ayocodingit @imamdev93 