### PR TITLE
fix time server to run cron

### DIFF
--- a/service-worker/src/cmd/main.go
+++ b/service-worker/src/cmd/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jabardigitalservice/portal-jabar-services/service-worker/src/config"
 	"github.com/jabardigitalservice/portal-jabar-services/service-worker/src/job"
 	"github.com/jabardigitalservice/portal-jabar-services/service-worker/src/utils"
-	"github.com/robfig/cron"
+	"github.com/robfig/cron/v3"
 )
 
 type worker struct {
@@ -35,8 +35,11 @@ func main() {
 	w := newWorker(context.TODO(), config.NewConfig(), utils.NewDBConn(config.NewConfig()))
 	go w.listenForMessages()
 
+	// set timezone at GMT+00
+	loc, _ := time.LoadLocation("GMT")
+
 	// set job runner
-	c := cron.New()
+	c := cron.New(cron.WithLocation(loc))
 	cfg := config.NewConfig()
 
 	// @daily is mean will run jobs every day on midnight (Equivalent to 0 0 * *)

--- a/service-worker/src/go.mod
+++ b/service-worker/src/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.2.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/robfig/cron v1.2.0
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.11.0
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect

--- a/service-worker/src/go.sum
+++ b/service-worker/src/go.sum
@@ -333,6 +333,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=


### PR DESCRIPTION
Overview
set cron to neutral time server (GMT)

cc: https://github.com/orgs/jabardigitalservice/teams/jds-backend

Evidence
project: Portal Jabar
title: penyesuai default time service worker
participants: @rachadiannovansyah @indraprasetya154 @ayocodingit @tukangremot @sandisunandar99 