### PR TITLE
update news public API for integration with APTIKA

### DIFF
--- a/core-service/src/domain/news.go
+++ b/core-service/src/domain/news.go
@@ -145,6 +145,21 @@ type TabStatusResponse struct {
 	Count  int    `json:"count"`
 }
 
+// NewsAptikaResponse is the response for news api Aptika for existing jabarprov
+type NewsAptikaResponse struct {
+	ID          int64      `json:"id"`
+	Title       string     `json:"Judul_berita"`
+	Excerpt     string     `json:"Lead_berita"`
+	PublishedAt *time.Time `json:"Tanggal"`
+	Content     string     `json:"Isi"`
+	Image       *string    `json:"Gambar"`
+	Category    string     `json:"Kategori"`
+	Area        Area       `json:"Area"`
+	CreatedBy   Author     `json:"Dibuat_oleh"`
+	CreatedAt   time.Time  `json:"Dibuat_pada"`
+	UpdatedAt   time.Time  `json:"Diubah_pada"`
+}
+
 // NewsUsecase represent the news usecases
 type NewsUsecase interface {
 	Fetch(ctx context.Context, au *JwtCustomClaims, params *Request) ([]News, int64, error)

--- a/core-service/src/modules/news/delivery/http/public_news_handler.go
+++ b/core-service/src/modules/news/delivery/http/public_news_handler.go
@@ -40,12 +40,24 @@ func (h *PublicNewsHandler) FetchNews(c echo.Context) error {
 		"tag":        c.QueryParam("tag"),
 		"status":     c.QueryParam("status"),
 		"exclude":    c.QueryParam("exclude"),
+		"isAptika":   c.QueryParam("isAptika"),
 	}
 
 	listNews, total, err := h.CUsecase.FetchPublished(ctx, &params)
 
 	if err != nil {
 		return err
+	}
+
+	// Set news response for API Aptika
+	isAptika, _ := strconv.ParseBool(params.Filters["isAptika"].(string))
+	if isAptika {
+		listAptikaNewsRes := []domain.NewsAptikaResponse{}
+		copier.Copy(&listAptikaNewsRes, &listNews)
+
+		res := helpers.Paginate(c, listAptikaNewsRes, total, params)
+
+		return c.JSON(http.StatusOK, res)
 	}
 
 	// Copy slice to slice


### PR DESCRIPTION
Overview
update news public API for integration with APTIKA
- add news list response for aptika
- add params flagging
- add layer area on news usecase

cc: https://github.com/orgs/jabardigitalservice/teams/jds-backend

Evidence
project: Portal Jabar
title: update publik API beria untuk OPD (Aptika)
participants: @rachadiannovansyah @rindibudiaramdhan @indraprasetya154 @ayocodingit @imamdev93 