### PR TITLE
Implement Redis-Go on Public API

### DIFF
--- a/core-service/src/cmd/server/repository.go
+++ b/core-service/src/cmd/server/repository.go
@@ -13,7 +13,6 @@ import (
 	_featuredProgramRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/featured-program/repository/mysql"
 	_feedbackRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/feedback/repository/mysql"
 	_informationRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/information/repository/mysql"
-	_mailRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/mail/repository/redis"
 	_newsRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/news/repository/mysql"
 	_regInvitationRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/registration-invitation/repository/mysql"
 	_rolePermRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/role-permission/repository/mysql"
@@ -67,7 +66,6 @@ func NewRepository(conn *utils.Conn) *Repository {
 		RolePermRepo:        _rolePermRepo.NewMysqlRolePermissionRepository(conn.Mysql),
 		TemplateRepo:        _templateRepo.NewMysqlMailTemplateRepository(conn.Mysql),
 		RegInvitationRepo:   _regInvitationRepo.NewMysqlRegInvitationRepository(conn.Mysql),
-		MailRepo:            _mailRepo.NewRedisMailRepository(conn.Redis),
 		AwardRepo:           _awardRepo.NewMysqlAwardRepository(conn.Mysql),
 		DistrictRepo:        _districtRepo.NewMysqlDistrictRepository(conn.Mysql),
 	}

--- a/core-service/src/config/redis.go
+++ b/core-service/src/config/redis.go
@@ -5,11 +5,13 @@ import "github.com/spf13/viper"
 type RedisConfig struct {
 	Host string
 	Port int
+	TTL  int
 }
 
 func LoadRedisConfig() RedisConfig {
 	return RedisConfig{
 		Host: viper.GetString("REDIS_HOST"),
 		Port: viper.GetInt("REDIS_PORT"),
+		TTL:  viper.GetInt("REDIS_TTL"),
 	}
 }

--- a/core-service/src/domain/news.go
+++ b/core-service/src/domain/news.go
@@ -31,8 +31,8 @@ type News struct {
 	Editor      *string    `json:"editor"`
 	Area        Area       `json:"area" validate:"required"`
 	Duration    int8       `json:"duration"`
-	StartDate   time.Time  `json:"start_date"`
-	EndDate     time.Time  `json:"end_date"`
+	StartDate   *time.Time `json:"start_date"`
+	EndDate     *time.Time `json:"end_date"`
 	IsLive      int8       `json:"is_live"`
 	CreatedBy   User       `json:"created_by"`
 	UpdatedBy   User       `json:"updated_by"`

--- a/core-service/src/domain/news.go
+++ b/core-service/src/domain/news.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 )
 
@@ -15,8 +16,8 @@ type News struct {
 	Content     string     `json:"content" validate:"required"`
 	Slug        string     `json:"slug"`
 	Image       *string    `json:"image"`
-	Video       NullString `json:"video"`
-	Source      NullString `json:"source"`
+	Video       *string    `json:"video"`
+	Source      *string    `json:"source"`
 	Status      string     `json:"status,omitempty"`
 	Views       int64      `json:"views"`
 	Shared      int64      `json:"shared"`
@@ -29,8 +30,8 @@ type News struct {
 	Editor      *string    `json:"editor"`
 	Area        Area       `json:"area" validate:"required"`
 	Duration    int8       `json:"duration"`
-	StartDate   NullTime   `json:"start_date"`
-	EndDate     NullTime   `json:"end_date"`
+	StartDate   time.Time  `json:"start_date"`
+	EndDate     time.Time  `json:"end_date"`
 	IsLive      int8       `json:"is_live"`
 	CreatedBy   User       `json:"created_by"`
 	UpdatedBy   User       `json:"updated_by"`
@@ -112,37 +113,42 @@ type NewsBanner struct {
 
 // DetailNewsResponse ...
 type DetailNewsResponse struct {
-	ID          int64            `json:"id"`
-	Title       string           `json:"title"`
-	Excerpt     string           `json:"excerpt"`
-	Content     string           `json:"content"`
-	Slug        string           `json:"slug"`
-	Image       *string          `json:"image"`
-	Video       NullString       `json:"video"`
-	Source      NullString       `json:"source"`
-	Status      string           `json:"status"`
-	Views       int64            `json:"views"`
-	Shared      int64            `json:"shared"`
-	Highlight   int8             `json:"highlight,omitempty"`
-	Type        string           `json:"type"`
-	Tags        []DataTag        `json:"tags"`
-	Category    string           `json:"category"`
-	Author      string           `json:"author"`
-	Reporter    string           `json:"reporter"`
-	Editor      string           `json:"editor"`
-	Duration    int8             `json:"duration"`
-	StartDate   NullTime         `json:"start_date"`
-	EndDate     NullTime         `json:"end_date"`
-	Area        AreaListResponse `json:"area"`
-	PublishedAt time.Time        `json:"published_at"`
-	CreatedBy   Author           `json:"created_by"`
-	CreatedAt   time.Time        `json:"created_at"`
-	UpdatedAt   time.Time        `json:"updated_at"`
+	ID          int64             `json:"id"`
+	Title       string            `json:"title"`
+	Excerpt     string            `json:"excerpt"`
+	Content     string            `json:"content"`
+	Slug        string            `json:"slug"`
+	Image       *string           `json:"image"`
+	Video       *string           `json:"video"`
+	Source      *string           `json:"source"`
+	Status      string            `json:"status"`
+	Views       int64             `json:"views"`
+	Shared      int64             `json:"shared"`
+	Highlight   int8              `json:"highlight,omitempty"`
+	Type        string            `json:"type"`
+	Tags        []DataTag         `json:"tags"`
+	Category    string            `json:"category"`
+	Author      string            `json:"author"`
+	Reporter    string            `json:"reporter"`
+	Editor      string            `json:"editor"`
+	Duration    int8              `json:"duration"`
+	StartDate   *time.Time        `json:"start_date"`
+	EndDate     *time.Time        `json:"end_date"`
+	Area        *AreaListResponse `json:"area"`
+	PublishedAt time.Time         `json:"published_at"`
+	CreatedBy   Author            `json:"created_by"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
 }
 
 type TabStatusResponse struct {
 	Status string `json:"status"`
 	Count  int    `json:"count"`
+}
+
+func (i DetailNewsResponse) MarshalBinary() ([]byte, error) {
+	bytes, err := json.Marshal(i)
+	return bytes, err
 }
 
 // NewsUsecase represent the news usecases

--- a/core-service/src/domain/redis.go
+++ b/core-service/src/domain/redis.go
@@ -1,0 +1,6 @@
+package domain
+
+// struct for redis
+type ResRedis struct {
+	Data interface{} `json:"data"`
+}

--- a/core-service/src/go.mod
+++ b/core-service/src/go.mod
@@ -13,12 +13,14 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.0.0-20211104170603-75263a5e99d2
 	github.com/getsentry/sentry-go v0.11.0
 	github.com/go-playground/universal-translator v0.18.0 // indirect
+	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang-migrate/migrate v3.5.4+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/gosimple/slug v1.12.0
 	github.com/jinzhu/copier v0.3.2
+	github.com/kr/pretty v0.2.1 // indirect
 	github.com/labstack/echo/v4 v4.5.0
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.1

--- a/core-service/src/go.sum
+++ b/core-service/src/go.sum
@@ -341,6 +341,8 @@ github.com/go-playground/locales v0.14.0 h1:u50s323jtVGugKlcYeyzC0etD1HifMjqmJqb
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=
 github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/jYrnRPArHwAcmLoJZxyho=
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
+github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-redis/redis/v8 v8.11.4 h1:kHoYkfZP6+pe04aFTnhDH6GDROa5yJdHJVNxV3F46Tg=
 github.com/go-redis/redis/v8 v8.11.4/go.mod h1:2Z2wHZXdQpCDXEGzqMockDpNyYvi2l4Pxt6RJr792+w=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=

--- a/core-service/src/helpers/getters.go
+++ b/core-service/src/helpers/getters.go
@@ -133,10 +133,9 @@ func GetCachedData(c echo.Context) (memcache string) {
 	memcache, _ = cache.Get(key).Result()
 
 	if memcache != "" {
-		fmt.Println("Data using cache")
+		fmt.Println("Cached!")
 		return
 	}
-	fmt.Println("Data not using cache")
 
 	return
 }

--- a/core-service/src/helpers/getters.go
+++ b/core-service/src/helpers/getters.go
@@ -1,11 +1,14 @@
 package helpers
 
 import (
+	"fmt"
 	"math"
 	"net/http"
 	"strconv"
 
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/config"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/utils"
 	"github.com/labstack/echo/v4"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
@@ -118,6 +121,24 @@ func GetAuthenticatedUser(c echo.Context) *domain.JwtCustomClaims {
 	auth := domain.JwtCustomClaims{}
 	mapstructure.Decode(c.Get("auth:user"), &auth)
 	return &auth
+}
+
+// GetCachedRedisData ...
+func GetCachedData(c echo.Context) (memcache string) {
+	cfg := config.NewConfig()
+	cache := utils.NewDBConn(cfg).Redis
+
+	// Get cached data
+	key := c.Param("slug")
+	memcache, _ = cache.Get(key).Result()
+
+	if memcache != "" {
+		fmt.Println("Data using cache")
+		return
+	}
+	fmt.Println("Data not using cache")
+
+	return
 }
 
 // GetUnitInfo ...

--- a/core-service/src/middleware/permission.go
+++ b/core-service/src/middleware/permission.go
@@ -1,7 +1,9 @@
 package middleware
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
@@ -22,13 +24,32 @@ func CheckPermission(permission string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			au := helpers.GetAuthenticatedUser(c)
-
 			if au.Role.ID == domain.RoleSuperAdmin {
 				return next(c)
 			}
 
 			if !hasPermission(permission, au.Permissions) {
 				return c.JSON(http.StatusForbidden, domain.NewErrResponse(errors.New("permission denied")))
+			}
+
+			return next(c)
+		}
+	}
+}
+
+func CheckCache() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			memcached := helpers.GetCachedData(c)
+
+			if memcached != "" {
+				var cacheRes domain.DetailNewsResponse
+				err := json.Unmarshal([]byte(memcached), &cacheRes)
+				if err != nil {
+					fmt.Println(err)
+				}
+
+				return c.JSON(http.StatusOK, &domain.ResultData{Data: &cacheRes})
 			}
 
 			return next(c)

--- a/core-service/src/modules/news/delivery/http/public_news_handler.go
+++ b/core-service/src/modules/news/delivery/http/public_news_handler.go
@@ -18,7 +18,6 @@ import (
 // PublicNewsHandler ...
 type PublicNewsHandler struct {
 	CUsecase domain.NewsUsecase
-	Red      string `json:"red"`
 }
 
 // NewPublicNewsHandler will initialize the /public/news handler

--- a/core-service/src/modules/news/delivery/http/public_news_handler.go
+++ b/core-service/src/modules/news/delivery/http/public_news_handler.go
@@ -89,7 +89,7 @@ func (h *PublicNewsHandler) GetBySlug(c echo.Context) error {
 	copier.Copy(&newsRes, &news)
 
 	// set ttl cache 5 minutes after store in redis
-	ttl := 5 * time.Minute
+	ttl := time.Duration(cfg.Redis.TTL) * time.Second
 	cacheErr := cache.Set(slug, &newsRes, ttl).Err()
 	if cacheErr != nil {
 		return cacheErr

--- a/core-service/src/modules/news/repository/mysql/mysql_news_test.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news_test.go
@@ -17,6 +17,7 @@ func TestFetch(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 
+	currentTime := time.Now()
 	mockNews := []domain.News{
 		{
 			ID:        1,
@@ -26,8 +27,8 @@ func TestFetch(t *testing.T) {
 			Views:     10,
 			Shared:    25,
 			Image:     nil,
-			StartDate: time.Now(),
-			EndDate:   time.Now(),
+			StartDate: &currentTime,
+			EndDate:   &currentTime,
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 		},
@@ -39,8 +40,8 @@ func TestFetch(t *testing.T) {
 			Views:     15,
 			Shared:    30,
 			Image:     nil,
-			StartDate: time.Now(),
-			EndDate:   time.Now(),
+			StartDate: &currentTime,
+			EndDate:   &currentTime,
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 		},

--- a/core-service/src/modules/news/repository/mysql/mysql_news_test.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news_test.go
@@ -26,8 +26,8 @@ func TestFetch(t *testing.T) {
 			Views:     10,
 			Shared:    25,
 			Image:     nil,
-			StartDate: domain.NullTime{Time: time.Now(), Valid: true},
-			EndDate:   domain.NullTime{Time: time.Now(), Valid: true},
+			StartDate: time.Now(),
+			EndDate:   time.Now(),
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 		},
@@ -39,8 +39,8 @@ func TestFetch(t *testing.T) {
 			Views:     15,
 			Shared:    30,
 			Image:     nil,
-			StartDate: domain.NullTime{Time: time.Now(), Valid: true},
-			EndDate:   domain.NullTime{Time: time.Now(), Valid: true},
+			StartDate: time.Now(),
+			EndDate:   time.Now(),
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 		},
@@ -48,9 +48,9 @@ func TestFetch(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "category", "title", "excerpt", "content", "image", "video", "slug", "author", "reporter", "editor", "area_id", "type", "views", "shared", "source", "duration", "start_date", "end_date", "status", "is_live", "published_at", "created_by", "created_at", "updated_at"}).
 		AddRow(mockNews[0].ID, mockNews[0].Category, mockNews[0].Title, mockNews[0].Excerpt, mockNews[0].Content,
-			nil, nil, mockNews[0].Slug, "", "", "", 0, "", mockNews[0].Views, mockNews[0].Shared, mockNews[0].Source.String, 0, mockNews[0].StartDate.Time, mockNews[0].EndDate.Time, mockNews[0].Status, 0, mockNews[0].PublishedAt, nil, mockNews[0].CreatedAt, mockNews[0].UpdatedAt).
+			nil, nil, mockNews[0].Slug, "", "", "", 0, "", mockNews[0].Views, mockNews[0].Shared, mockNews[0].Source, 0, mockNews[0].StartDate, mockNews[0].EndDate, mockNews[0].Status, 0, mockNews[0].PublishedAt, nil, mockNews[0].CreatedAt, mockNews[0].UpdatedAt).
 		AddRow(mockNews[1].ID, mockNews[1].Category, mockNews[1].Title, mockNews[1].Excerpt, mockNews[1].Content,
-			nil, nil, mockNews[1].Slug, "", "", "", 0, "", mockNews[1].Views, mockNews[1].Shared, mockNews[1].Source.String, 0, mockNews[1].StartDate.Time, mockNews[1].EndDate.Time, mockNews[1].Status, 0, mockNews[1].PublishedAt, nil, mockNews[1].CreatedAt, mockNews[1].UpdatedAt)
+			nil, nil, mockNews[1].Slug, "", "", "", 0, "", mockNews[1].Views, mockNews[1].Shared, mockNews[1].Source, 0, mockNews[1].StartDate, mockNews[1].EndDate, mockNews[1].Status, 0, mockNews[1].PublishedAt, nil, mockNews[1].CreatedAt, mockNews[1].UpdatedAt)
 
 	query := "SELECT n.id, n.category, n.title, n.excerpt, n.content, n.image, n.video, n.slug, n.author, n.reporter, n.editor, n.area_id, n.type, n.views, n.shared, n.source, n.duration, n.start_date, n.end_date, n.status, n.is_live, n.published_at, n.created_by, n.created_at, n.updated_at FROM news n LEFT JOIN users u ON n.created_by = u.id WHERE n.deleted_at is NULL"
 

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -543,8 +543,8 @@ func (n *newsUsecase) UpdateStatus(c context.Context, id int64, status string) (
 	news.Status = status
 
 	newsRequest := domain.StoreNewsRequest{
-		StartDate: helpers.ConvertTimeToString(news.StartDate.Time),
-		EndDate:   helpers.ConvertTimeToString(news.EndDate.Time),
+		StartDate: helpers.ConvertTimeToString(news.StartDate),
+		EndDate:   helpers.ConvertTimeToString(news.EndDate),
 		AreaID:    news.Area.ID,
 	}
 	copier.Copy(&newsRequest, &news)

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -603,8 +603,8 @@ func (n *newsUsecase) UpdateStatus(c context.Context, id int64, status string) (
 	news.Status = status
 
 	newsRequest := domain.StoreNewsRequest{
-		StartDate: helpers.ConvertTimeToString(news.StartDate),
-		EndDate:   helpers.ConvertTimeToString(news.EndDate),
+		StartDate: helpers.ConvertTimeToString(news.StartDate.UTC()),
+		EndDate:   helpers.ConvertTimeToString(news.EndDate.UTC()),
 		AreaID:    news.Area.ID,
 	}
 	copier.Copy(&newsRequest, &news)

--- a/core-service/src/utils/connection.go
+++ b/core-service/src/utils/connection.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/go-redis/redis/v8"
+	"github.com/go-redis/redis"
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/config"
 )
@@ -52,7 +52,7 @@ func initRedisClient(cfg *config.Config) *redis.Client {
 		Addr: fmt.Sprintf("%s:%d", cfg.Redis.Host, cfg.Redis.Port),
 	})
 
-	_, err := rdb.Ping(rdb.Context()).Result()
+	_, err := rdb.Ping().Result()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Overview
Implement Redis on Public API

- create own Middleware to check `verify cache`
- set it to public API (slug news api)
- change attribute type of `NullString`, `NullTime`, `NullInt` instead of Pointer

cc: https://github.com/orgs/jabardigitalservice/teams/jds-backend

Evidence
project: Portal Jabar
title: Redis cache on public API to enhance performance
participants: @rachadiannovansyah @ayocodingit 