### PR TITLE
module feedback response adjustment

### DIFF
--- a/core-service/src/database/migrations/20220803070120_add_column_sector_on_feedback_tables.up.sql
+++ b/core-service/src/database/migrations/20220803070120_add_column_sector_on_feedback_tables.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE feedback ADD COLUMN sector VARCHAR(100) NULL AFTER suggestions;
+ALTER TABLE feedback ADD COLUMN sector text NULL AFTER suggestions;

--- a/core-service/src/domain/feedback.go
+++ b/core-service/src/domain/feedback.go
@@ -14,7 +14,6 @@ type Feedback struct {
 	Suggestions string    `json:"suggestions" validate:"required,max=1500"`
 	Sector      string    `json:"sector" validate:"required,max=1500"`
 	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 // FeedbackUsecase is an interface for feedback use cases

--- a/core-service/src/modules/feedback/repository/mysql/mysql_feedback.go
+++ b/core-service/src/modules/feedback/repository/mysql/mysql_feedback.go
@@ -17,13 +17,13 @@ func NewMysqlFeedbackRepository(Conn *sql.DB) domain.FeedbackRepository {
 }
 
 func (m *mysqlFeedbackRepository) Store(ctx context.Context, f *domain.Feedback) (err error) {
-	query := `INSERT feedback SET rating=? , compliments=? , criticism=?, suggestions=?, sector=?`
+	query := `INSERT feedback SET rating=? , compliments=? , criticism=?, suggestions=?, sector=?, created_at=?`
 	stmt, err := m.Conn.PrepareContext(ctx, query)
 	if err != nil {
 		return
 	}
 
-	res, err := stmt.ExecContext(ctx, f.Rating, f.Compliments, f.Criticism, f.Suggestions, f.Sector)
+	res, err := stmt.ExecContext(ctx, f.Rating, f.Compliments, f.Criticism, f.Suggestions, f.Sector, f.CreatedAt)
 	if err != nil {
 		return
 	}

--- a/core-service/src/modules/feedback/usecase/feedback_ucase.go
+++ b/core-service/src/modules/feedback/usecase/feedback_ucase.go
@@ -23,6 +23,7 @@ func NewFeedbackUsecase(f domain.FeedbackRepository, timeout time.Duration) doma
 func (u *feedbackUsecase) Store(c context.Context, f *domain.Feedback) (err error) {
 	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
 	defer cancel()
+	f.CreatedAt = time.Now()
 	err = u.feedbackRepo.Store(ctx, f)
 	return
 }


### PR DESCRIPTION
Overview
adjust response api
  - no longer need `updated_at` column on feedback

cc: https://github.com/orgs/jabardigitalservice/teams/jds-backend

Evidence
project: Portal Jabar
title: Penyesuaian response feedback
participants: @rachadiannovansyah @rindibudiaramdhan @ayocodingit 