### PR TITLE
remove rate limiter app

### DIFF
--- a/core-service/src/cmd/server/handler.go
+++ b/core-service/src/cmd/server/handler.go
@@ -63,7 +63,6 @@ func NewHandler(cfg *config.Config, apm *utils.Apm, u *Usecases) {
 	e.Use(nrecho.Middleware(apm.NewRelic))
 	e.Use(middleware.CORSWithConfig(cfg.Cors))
 	e.Use(sentryecho.New(sentryecho.Options{Repanic: true}))
-	e.Use(middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(20)))
 
 	newAppHandler(e)
 	_areaHttpDelivery.NewAreaHandler(v1, r, u.AreaUcase)


### PR DESCRIPTION
Overview
- No longer use rate limiter on App
- Now rate limiter are adjusting on `ingress`

cc: https://github.com/orgs/jabardigitalservice/teams/jds-backend

Evidence
project: Portal Jabar
title: Menghilangkan rate limiter aplikasi, beralih menggunakan ingress
participants: @rachadiannovansyah @indraprasetya154 @ayocodingit 