### PR TITLE
Public service/api indexing

### DIFF
--- a/core-service/src/cmd/server/handler.go
+++ b/core-service/src/cmd/server/handler.go
@@ -27,6 +27,7 @@ import (
 	_feedbackHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/feedback/delivery/http"
 	_informationHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/information/delivery/http"
 	_newsHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/news/delivery/http"
+	_publicServiceHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/public-service/delivery/http"
 	_regInvitationHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/registration-invitation/delivery/http"
 	_searchHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/search/delivery/http"
 	_tagHttpDelivery "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/tag/delivery/http"
@@ -81,6 +82,7 @@ func NewHandler(cfg *config.Config, apm *utils.Apm, u *Usecases) {
 	_awardHttpDelivery.NewAwardHandler(v1, u.AwardUsecase)
 	_districtHttpDelivery.NewDistrictHandler(v1, u.DistrictUsecase)
 	_publicDocumentArchiveHttpDelivery.NewPublicDocumentArchiveHandler(p, u.DocumentArchiveUsecase)
+	_publicServiceHttpDelivery.NewPublicServiceHandler(v1, r, u.PublicServiceUsecase)
 
 	log.Fatal(e.Start(viper.GetString("APP_ADDRESS")))
 }

--- a/core-service/src/cmd/server/repository.go
+++ b/core-service/src/cmd/server/repository.go
@@ -15,6 +15,7 @@ import (
 	_feedbackRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/feedback/repository/mysql"
 	_informationRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/information/repository/mysql"
 	_newsRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/news/repository/mysql"
+	_publicServiceRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/public-service/repository/mysql"
 	_regInvitationRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/registration-invitation/repository/mysql"
 	_rolePermRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/role-permission/repository/mysql"
 	_roleRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/role/repository/mysql"
@@ -47,6 +48,7 @@ type Repository struct {
 	AwardRepo           domain.AwardRepository
 	DistrictRepo        domain.DistrictRepository
 	DocumentArchiveRepo domain.DocumentArchiveRepository
+	PublicServiceRepo   domain.PublicServiceRepository
 }
 
 // NewRepository will create an object that represent all repos interface
@@ -71,5 +73,6 @@ func NewRepository(conn *utils.Conn) *Repository {
 		AwardRepo:           _awardRepo.NewMysqlAwardRepository(conn.Mysql),
 		DistrictRepo:        _districtRepo.NewMysqlDistrictRepository(conn.Mysql),
 		DocumentArchiveRepo: _documentArchiveRepo.NewMysqlDocumentArchiveRepository(conn.Mysql),
+		PublicServiceRepo:   _publicServiceRepo.NewMysqlPublicServiceRepository(conn.Mysql),
 	}
 }

--- a/core-service/src/cmd/server/usecase.go
+++ b/core-service/src/cmd/server/usecase.go
@@ -18,6 +18,7 @@ import (
 	_informationUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/information/usecase"
 	_mediaUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/media/usecase"
 	_newsUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/news/usecase"
+	_publicServiceUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/public-service/usecase"
 	_regInvitationUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/registration-invitation/usecase"
 	_searchUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/search/usecase"
 	_tagUcase "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/tag/usecase"
@@ -46,6 +47,7 @@ type Usecases struct {
 	AwardUsecase           domain.AwardUsecase
 	DistrictUsecase        domain.DistrictUsecase
 	DocumentArchiveUsecase domain.DocumentArchiveUsecase
+	PublicServiceUsecase   domain.PublicServiceUsecase
 }
 
 // NewUcase will create an object that represent all usecases interface
@@ -68,5 +70,6 @@ func NewUcase(cfg *config.Config, conn *utils.Conn, r *Repository, timeoutContex
 		AwardUsecase:           _awardUcase.NewAwardUsecase(r.AwardRepo, timeoutContext),
 		DistrictUsecase:        _districtUcase.NewDistrictUsecase(r.DistrictRepo, timeoutContext),
 		DocumentArchiveUsecase: _documentArchiveUcase.NewDocumentArchiveUsecase(r.DocumentArchiveRepo, r.UserRepo, cfg, timeoutContext),
+		PublicServiceUsecase:   _publicServiceUcase.NewPublicServiceUsecase(r.PublicServiceRepo, r.UserRepo, r.SearchRepo, cfg, timeoutContext),
 	}
 }

--- a/core-service/src/database/migrations/20220901051558_add_column_category_and_is_active_on_public_services_table.down.sql
+++ b/core-service/src/database/migrations/20220901051558_add_column_category_and_is_active_on_public_services_table.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public_services 
+DROP COLUMN category,
+DROP COLUMN is_active;

--- a/core-service/src/database/migrations/20220901051558_add_column_category_and_is_active_on_public_services_table.up.sql
+++ b/core-service/src/database/migrations/20220901051558_add_column_category_and_is_active_on_public_services_table.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public_services 
+ADD COLUMN category varchar(100) NULL AFTER image,
+ADD COLUMN is_active tinyint(1) NULL after category;

--- a/core-service/src/domain/public_service.go
+++ b/core-service/src/domain/public_service.go
@@ -13,10 +13,31 @@ type PublicService struct {
 	Unit        NullString `json:"unit"`
 	Url         NullString `json:"url"`
 	Image       NullString `json:"image"`
+	Category    NullString `json:"category"`
+	IsActive    NullString `json:"is_active"`
 	CreatedAt   time.Time  `json:"created_at"`
 	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
+type StorePserviceRequest struct {
+	ID          int64     `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Url         string    `json:"url"`
+	Image       string    `json:"image"`
+	Category    string    `json:"category"`
+	IsActive    int8      `json:"is_active"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// PublicServiceUsecase ...
+type PublicServiceUsecase interface {
+	Store(context.Context, *StorePserviceRequest) error
+}
+
+// PublicServiceRepository ...
 type PublicServiceRepository interface {
 	Fetch(ctx context.Context, params *Request) ([]PublicService, error)
+	Store(ctx context.Context, params *StorePserviceRequest) error
 }

--- a/core-service/src/domain/public_service.go
+++ b/core-service/src/domain/public_service.go
@@ -23,6 +23,7 @@ type StorePserviceRequest struct {
 	ID          int64     `json:"id"`
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
+	Unit        string    `json:"unit,omitempty"`
 	Url         string    `json:"url"`
 	Image       string    `json:"image"`
 	Category    string    `json:"category"`
@@ -33,11 +34,13 @@ type StorePserviceRequest struct {
 
 // PublicServiceUsecase ...
 type PublicServiceUsecase interface {
-	Store(context.Context, *StorePserviceRequest) error
+	Store(ctx context.Context, ps *StorePserviceRequest) (err error)
+	Delete(ctx context.Context, id int64) error
 }
 
 // PublicServiceRepository ...
 type PublicServiceRepository interface {
 	Fetch(ctx context.Context, params *Request) ([]PublicService, error)
 	Store(ctx context.Context, params *StorePserviceRequest) error
+	Delete(ctx context.Context, id int64) error
 }

--- a/core-service/src/modules/public-service/delivery/http/public_service_handler.go
+++ b/core-service/src/modules/public-service/delivery/http/public_service_handler.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"gopkg.in/go-playground/validator.v9"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+)
+
+// PublicServiceHandler ...
+type PublicServiceHandler struct {
+	PSUsecase domain.PublicServiceUsecase
+}
+
+// NewPublicServiceHandler will create a new PublicServiceHandler
+func NewPublicServiceHandler(e *echo.Group, r *echo.Group, ps domain.PublicServiceUsecase) {
+	handler := &PublicServiceHandler{
+		PSUsecase: ps,
+	}
+	r.POST("/public-service", handler.Store)
+}
+
+func isRequestValid(f *domain.StorePserviceRequest) (bool, error) {
+	validate := validator.New()
+	err := validate.Struct(f)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Store will store the public-service by given request body
+func (h *PublicServiceHandler) Store(c echo.Context) (err error) {
+	ps := new(domain.StorePserviceRequest)
+	if err = c.Bind(ps); err != nil {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
+	}
+
+	var ok bool
+	if ok, err = isRequestValid(ps); !ok {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	ctx := c.Request().Context()
+	err = h.PSUsecase.Store(ctx, ps)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusCreated, ps)
+}

--- a/core-service/src/modules/public-service/delivery/http/public_service_handler.go
+++ b/core-service/src/modules/public-service/delivery/http/public_service_handler.go
@@ -2,11 +2,13 @@ package http
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
 )
 
 // PublicServiceHandler ...
@@ -20,6 +22,7 @@ func NewPublicServiceHandler(e *echo.Group, r *echo.Group, ps domain.PublicServi
 		PSUsecase: ps,
 	}
 	r.POST("/public-service", handler.Store)
+	r.DELETE("/public-service/:id", handler.Delete)
 }
 
 func isRequestValid(f *domain.StorePserviceRequest) (bool, error) {
@@ -33,16 +36,19 @@ func isRequestValid(f *domain.StorePserviceRequest) (bool, error) {
 
 // Store will store the public-service by given request body
 func (h *PublicServiceHandler) Store(c echo.Context) (err error) {
+	// binding a request body to domain.StorePserviceRequest struct
 	ps := new(domain.StorePserviceRequest)
 	if err = c.Bind(ps); err != nil {
 		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
 	}
 
+	// check an requests is valid or not
 	var ok bool
 	if ok, err = isRequestValid(ps); !ok {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
+	// store public-service
 	ctx := c.Request().Context()
 	err = h.PSUsecase.Store(ctx, ps)
 	if err != nil {
@@ -50,4 +56,24 @@ func (h *PublicServiceHandler) Store(c echo.Context) (err error) {
 	}
 
 	return c.JSON(http.StatusCreated, ps)
+}
+
+// Delete will drop the public-service data by given id
+func (h *PublicServiceHandler) Delete(c echo.Context) (err error) {
+	reqID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return c.JSON(http.StatusNotFound, domain.ErrNotFound.Error())
+	}
+
+	// set request
+	id := int64(reqID)
+	ctx := c.Request().Context()
+
+	// destroy public-service data by given id
+	err = h.PSUsecase.Delete(ctx, id)
+	if err != nil {
+		return c.JSON(helpers.GetStatusCode(err), helpers.ResponseError{Message: err.Error()})
+	}
+
+	return c.NoContent(http.StatusNoContent)
 }

--- a/core-service/src/modules/public-service/repository/mysql/mysql_public_service.go
+++ b/core-service/src/modules/public-service/repository/mysql/mysql_public_service.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 
@@ -83,7 +84,7 @@ func (m *mysqlPublicServiceRepository) Fetch(ctx context.Context, params *domain
 }
 
 func (m *mysqlPublicServiceRepository) Store(ctx context.Context, ps *domain.StorePserviceRequest) (err error) {
-	query := `INSERT public_service SET name=?, description=?, url=?, image=?, category=?, is_active=?, created_at=?, updated_at=?`
+	query := `INSERT public_services SET name=?, description=?, unit=?, url=?, image=?, category=?, is_active=?, created_at=?, updated_at=?`
 	stmt, err := m.Conn.PrepareContext(ctx, query)
 	if err != nil {
 		return
@@ -92,6 +93,7 @@ func (m *mysqlPublicServiceRepository) Store(ctx context.Context, ps *domain.Sto
 	res, err := stmt.ExecContext(ctx,
 		ps.Name,
 		ps.Description,
+		ps.Unit,
 		ps.Url,
 		ps.Image,
 		ps.Category,
@@ -110,6 +112,34 @@ func (m *mysqlPublicServiceRepository) Store(ctx context.Context, ps *domain.Sto
 	}
 
 	ps.ID = lastID
+
+	return
+}
+
+func (m *mysqlPublicServiceRepository) Delete(ctx context.Context, id int64) (err error) {
+	// binding data from a request
+	query := "DELETE FROM public_services WHERE id = ? "
+	stmt, err := m.Conn.PrepareContext(ctx, query)
+	if err != nil {
+		return
+	}
+
+	// exec an query
+	res, err := stmt.ExecContext(ctx, id)
+	if err != nil {
+		return
+	}
+
+	// get affected row
+	rowAffected, err := res.RowsAffected()
+	if err != nil {
+		return
+	}
+
+	if rowAffected != 1 {
+		err = fmt.Errorf("Weird Behavior. Total Affected: %d", rowAffected)
+		return
+	}
 
 	return
 }

--- a/core-service/src/modules/public-service/repository/mysql/mysql_public_service.go
+++ b/core-service/src/modules/public-service/repository/mysql/mysql_public_service.go
@@ -81,3 +81,35 @@ func (m *mysqlPublicServiceRepository) Fetch(ctx context.Context, params *domain
 
 	return
 }
+
+func (m *mysqlPublicServiceRepository) Store(ctx context.Context, ps *domain.StorePserviceRequest) (err error) {
+	query := `INSERT public_service SET name=?, description=?, url=?, image=?, category=?, is_active=?, created_at=?, updated_at=?`
+	stmt, err := m.Conn.PrepareContext(ctx, query)
+	if err != nil {
+		return
+	}
+
+	res, err := stmt.ExecContext(ctx,
+		ps.Name,
+		ps.Description,
+		ps.Url,
+		ps.Image,
+		ps.Category,
+		ps.IsActive,
+		ps.CreatedAt,
+		ps.UpdatedAt,
+	)
+
+	if err != nil {
+		return
+	}
+
+	lastID, err := res.LastInsertId()
+	if err != nil {
+		return
+	}
+
+	ps.ID = lastID
+
+	return
+}

--- a/core-service/src/modules/public-service/usecase/public_service_ucase.go
+++ b/core-service/src/modules/public-service/usecase/public_service_ucase.go
@@ -1,0 +1,55 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/config"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+)
+
+type publicServiceUsecase struct {
+	publicServiceRepo domain.PublicServiceRepository
+	userRepo          domain.UserRepository
+	searchRepo        domain.SearchRepository
+	cfg               *config.Config
+	contextTimeout    time.Duration
+}
+
+// NewPublicServiceUsecase creates a new feedback usecase
+func NewPublicServiceUsecase(ps domain.PublicServiceRepository, u domain.UserRepository, sr domain.SearchRepository, cfg *config.Config, timeout time.Duration) domain.PublicServiceUsecase {
+	return &publicServiceUsecase{
+		publicServiceRepo: ps,
+		userRepo:          u,
+		searchRepo:        sr,
+		cfg:               cfg,
+		contextTimeout:    timeout,
+	}
+}
+
+func (p *publicServiceUsecase) Store(c context.Context, ps *domain.StorePserviceRequest) (err error) {
+	ctx, cancel := context.WithTimeout(c, p.contextTimeout)
+	defer cancel()
+
+	ps.CreatedAt = time.Now()
+	ps.UpdatedAt = time.Now()
+
+	if err = p.publicServiceRepo.Store(ctx, ps); err != nil {
+		return
+	}
+
+	// FIXME: make a function to prepare data for search index
+	err = p.searchRepo.Store(ctx, p.cfg.ELastic.IndexContent, &domain.Search{
+		ID:        int(ps.ID),
+		Domain:    "public_service",
+		Title:     ps.Name,
+		Content:   ps.Description,
+		Category:  ps.Category,
+		Thumbnail: ps.Image,
+		CreatedAt: ps.CreatedAt,
+		UpdatedAt: ps.UpdatedAt,
+		IsActive:  ps.IsActive == 1,
+	})
+
+	return
+}

--- a/core-service/src/modules/public-service/usecase/public_service_ucase.go
+++ b/core-service/src/modules/public-service/usecase/public_service_ucase.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/config"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/sirupsen/logrus"
 )
 
 type publicServiceUsecase struct {
@@ -16,7 +17,7 @@ type publicServiceUsecase struct {
 	contextTimeout    time.Duration
 }
 
-// NewPublicServiceUsecase creates a new feedback usecase
+// NewPublicServiceUsecase creates a new public-service usecase
 func NewPublicServiceUsecase(ps domain.PublicServiceRepository, u domain.UserRepository, sr domain.SearchRepository, cfg *config.Config, timeout time.Duration) domain.PublicServiceUsecase {
 	return &publicServiceUsecase{
 		publicServiceRepo: ps,
@@ -40,16 +41,35 @@ func (p *publicServiceUsecase) Store(c context.Context, ps *domain.StorePservice
 
 	// FIXME: make a function to prepare data for search index
 	err = p.searchRepo.Store(ctx, p.cfg.ELastic.IndexContent, &domain.Search{
-		ID:        int(ps.ID),
-		Domain:    "public_service",
-		Title:     ps.Name,
-		Content:   ps.Description,
-		Category:  ps.Category,
-		Thumbnail: ps.Image,
-		CreatedAt: ps.CreatedAt,
-		UpdatedAt: ps.UpdatedAt,
-		IsActive:  ps.IsActive == 1,
+		ID:          int(ps.ID),
+		Domain:      "public_service",
+		Title:       ps.Name,
+		Content:     ps.Description,
+		Category:    ps.Category,
+		Thumbnail:   ps.Image,
+		PublishedAt: &time.Time{},
+		CreatedAt:   ps.CreatedAt,
+		UpdatedAt:   ps.UpdatedAt,
+		IsActive:    ps.IsActive == 1,
 	})
+
+	return
+}
+
+func (p *publicServiceUsecase) Delete(c context.Context, id int64) (err error) {
+	ctx, cancel := context.WithTimeout(c, p.contextTimeout)
+	defer cancel()
+
+	// delete public service from main db
+	if err = p.publicServiceRepo.Delete(ctx, id); err != nil {
+		return
+	}
+
+	// un-indexing public service on elastic based on id and domain
+	esErr := p.searchRepo.Delete(ctx, p.cfg.ELastic.IndexContent, int(id), "public_service")
+	if err != nil {
+		logrus.Error(esErr)
+	}
 
 	return
 }


### PR DESCRIPTION
### Overview
New API for Public Services

### Changes
- alter the migration column to add fields `category` and `is_active`
- binding a request and using parameters queries to mitigate SQL injection
- add post API to store & index to elastic search
- add delete API to un-indexing data from elastic search

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Menambahkan fungsi untuk indexing data layanan public
participants: @rachadiannovansyah @ayocodingit 