### PR TITLE
no longer use sort on query search

### DIFF
--- a/core-service/src/modules/search/repository/elastic/elastic_search.go
+++ b/core-service/src/modules/search/repository/elastic/elastic_search.go
@@ -73,17 +73,9 @@ func buildQuery(params *domain.Request) (buf bytes.Buffer) {
 		domain = domainFilter
 	}
 
-	paramsSort := q{"created_at": q{"order": params.SortOrder}}
-	if sortFilter := params.SortBy; len(sortFilter) > 0 {
-		paramsSort = q{params.SortBy: q{"order": params.SortOrder}}
-	}
-
 	query := q{
 		"_source": q{
 			"includes": []string{"id", "domain", "title", "excerpt", "slug", "category", "thumbnail", "content", "unit", "url", "published_at", "created_at"},
-		},
-		"sort": []map[string]interface{}{
-			paramsSort,
 		},
 		"query": q{
 			"bool": q{


### PR DESCRIPTION
### Overview
Adjust Query Elasticsearch to use `_score` for sorting result data
![image](https://user-images.githubusercontent.com/32012588/188365804-09c06412-c5fc-463a-9110-28b51fa3d680.png)

### Changes
- no longer use sort on query

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Penyesuaian query elasticsearch
participants: @rachadiannovansyah @sandisunandar99 @ayocodingit @rindibudiaramdhan @imamdev93 