### PR TITLE
update use case set prop live news

### DIFF
--- a/core-service/src/helpers/setters.go
+++ b/core-service/src/helpers/setters.go
@@ -10,6 +10,7 @@ import (
 func SetPropLiveNews(newsRequest *domain.StoreNewsRequest) {
 
 	currentTime := time.Now()
+	isLive := int8(1)
 	endDate := ConvertStringToTime(newsRequest.EndDate)
 	startDate := ConvertStringToTime(newsRequest.StartDate)
 	newsRequest.IsLive = 0
@@ -18,13 +19,23 @@ func SetPropLiveNews(newsRequest *domain.StoreNewsRequest) {
 	if time.Now().Unix() > endDate.Unix() {
 		newsRequest.StartDate = ConvertTimeToString(currentTime)
 		newsRequest.EndDate = ConvertTimeToString(currentTime.AddDate(0, 0, int(newsRequest.Duration)))
-		newsRequest.IsLive = 1
-		newsRequest.PublishedAt = &currentTime
+		setLiveAndPublish(newsRequest, isLive, currentTime)
 	}
 
 	// if startDate is less than equal to today, set live to true
 	if startDate.Unix() <= time.Now().Unix() {
-		newsRequest.IsLive = 1
-		newsRequest.PublishedAt = &currentTime
+		setLiveAndPublish(newsRequest, isLive, currentTime)
 	}
+}
+
+func setLiveAndPublish(newsRequest *domain.StoreNewsRequest, args ...interface{}) *domain.StoreNewsRequest {
+	// type assertion params
+	isLive := args[0].(int8)
+	publishedAt := args[1].(time.Time)
+
+	// set it to struct store request
+	newsRequest.IsLive = isLive
+	newsRequest.PublishedAt = &publishedAt
+
+	return newsRequest
 }

--- a/core-service/src/helpers/setters.go
+++ b/core-service/src/helpers/setters.go
@@ -7,15 +7,24 @@ import (
 )
 
 // SetPropLiveNews ...
-func SetPropLiveNews(news *domain.StoreNewsRequest) {
+func SetPropLiveNews(newsRequest *domain.StoreNewsRequest) {
 
 	currentTime := time.Now()
-	endDate := ConvertStringToTime(news.EndDate)
-	news.IsLive = 1
-	news.PublishedAt = &currentTime
+	endDate := ConvertStringToTime(newsRequest.EndDate)
+	startDate := ConvertStringToTime(newsRequest.StartDate)
+	newsRequest.IsLive = 0
+
 	// if endDate is exceed current time, set it to published at + duration
 	if time.Now().Unix() > endDate.Unix() {
-		news.StartDate = ConvertTimeToString(currentTime)
-		news.EndDate = ConvertTimeToString(currentTime.AddDate(0, 0, int(news.Duration)))
+		newsRequest.StartDate = ConvertTimeToString(currentTime)
+		newsRequest.EndDate = ConvertTimeToString(currentTime.AddDate(0, 0, int(newsRequest.Duration)))
+		newsRequest.IsLive = 1
+		newsRequest.PublishedAt = &currentTime
+	}
+
+	// if startDate is less than equal to today, set live to true
+	if startDate.Unix() <= time.Now().Unix() {
+		newsRequest.IsLive = 1
+		newsRequest.PublishedAt = &currentTime
 	}
 }


### PR DESCRIPTION
### Overview
Update use case set live props news

### Changes
- if end date news has expired, now admin still can make it publish
- the start and end date are adjusted by currentTime admin publish + duration of news

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Penyesuaian proses publish berita
participants: @rachadiannovansyah @sandisunandar99 @ayocodingit 