### PR TITLE
add track_scores on query elastic

### DIFF
--- a/core-service/src/modules/search/repository/elastic/elastic_search.go
+++ b/core-service/src/modules/search/repository/elastic/elastic_search.go
@@ -73,9 +73,19 @@ func buildQuery(params *domain.Request) (buf bytes.Buffer) {
 		domain = domainFilter
 	}
 
+	// set default sort by computed each _score documents
+	paramsSort := q{"_score": "desc"}
+	if sortFilter := params.SortBy; len(sortFilter) > 0 {
+		paramsSort = q{params.SortBy: q{"order": params.SortOrder}}
+	}
+
 	query := q{
 		"_source": q{
 			"includes": []string{"id", "domain", "title", "excerpt", "slug", "category", "thumbnail", "content", "unit", "url", "published_at", "created_at"},
+		},
+		"track_scores": true, // scores will still be computed and tracked
+		"sort": []map[string]interface{}{
+			paramsSort,
 		},
 		"query": q{
 			"bool": q{


### PR DESCRIPTION
### Overview
Add combined scores and another sort

## Changes
- set the `track_scores` is true will still be computed and tracked `_scores`
- now can sort with other values

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Enhance feature global search
participants: @rachadiannovansyah @sandisunandar99 @tukangremot @rindibudiaramdhan @ayocodingit @imamdev93 