### PR TITLE
update key cache using path query

### DIFF
--- a/core-service/src/helpers/redis.go
+++ b/core-service/src/helpers/redis.go
@@ -38,7 +38,7 @@ func SetCache(key string, value interface{}, ttl time.Duration) error {
 // func to get cache redis
 func GetCache(c echo.Context) (memcached string) {
 	// get url path from context
-	path := c.Request().URL.Path
+	path := c.Request().URL.RequestURI()
 
 	// Get cached redis data
 	memcached, _ = RedisCache().Get(path).Result()

--- a/core-service/src/modules/news/delivery/http/public_news_handler.go
+++ b/core-service/src/modules/news/delivery/http/public_news_handler.go
@@ -66,7 +66,7 @@ func (h *PublicNewsHandler) FetchNews(c echo.Context) error {
 	copier.Copy(&listNewsRes, &listNews)
 
 	// set cache from dependency injection redis
-	helpers.Cache(c.Request().URL.Path, listNewsRes)
+	helpers.Cache(c.Request().URL.RequestURI(), listNewsRes)
 
 	res := helpers.Paginate(c, listNewsRes, total, params)
 
@@ -88,7 +88,7 @@ func (h *PublicNewsHandler) GetBySlug(c echo.Context) error {
 	copier.Copy(&newsRes, &news)
 
 	// set cache from dependency injection redis
-	helpers.Cache(c.Request().URL.Path, newsRes)
+	helpers.Cache(c.Request().URL.RequestURI(), newsRes)
 
 	return c.JSON(http.StatusOK, &domain.ResultData{Data: &newsRes})
 }
@@ -105,7 +105,7 @@ func (h *PublicNewsHandler) FetchNewsBanner(c echo.Context) error {
 	}
 
 	// set cache from dependency injection redis
-	helpers.Cache(c.Request().URL.Path, listNews)
+	helpers.Cache(c.Request().URL.RequestURI(), listNews)
 
 	res := map[string]interface{}{
 		"data": listNews,
@@ -130,7 +130,7 @@ func (h *PublicNewsHandler) FetchNewsHeadline(c echo.Context) error {
 	copier.Copy(&headlineNewsRes, &headlineNews)
 
 	// set cache from dependency injection redis
-	helpers.Cache(c.Request().URL.Path, headlineNewsRes)
+	helpers.Cache(c.Request().URL.RequestURI(), headlineNewsRes)
 
 	res := map[string]interface{}{
 		"data": headlineNewsRes,


### PR DESCRIPTION
### Overview
No longer use `URL.Path` now uses `URL.RequestURI`

<img width="554" alt="image" src="https://user-images.githubusercontent.com/32012588/192690150-0aac8921-b38d-4b3c-83cd-32e149a45150.png">


## Evidence
project: Portal Jabar
title: Penyesuaian key cache redis
participants: @rachadiannovansyah @sandisunandar99 @ayocodingit @rhmnmbr83 