### PR TITLE
add optional filter by type and keywords

### DIFF
--- a/core-service/src/modules/public-service/delivery/http/public_service_handler.go
+++ b/core-service/src/modules/public-service/delivery/http/public_service_handler.go
@@ -29,6 +29,9 @@ func (h *PublicServiceHandler) Fetch(c echo.Context) error {
 
 	ctx := c.Request().Context()
 	params := helpers.GetRequestParams(c)
+	params.Filters = map[string]interface{}{
+		"service_type": c.QueryParam("type"),
+	}
 
 	publicServiceList, err := h.PSUsecase.Fetch(ctx, &params)
 

--- a/core-service/src/modules/public-service/repository/mysql/mysql_public_service.go
+++ b/core-service/src/modules/public-service/repository/mysql/mysql_public_service.go
@@ -99,7 +99,6 @@ func (m *mysqlPublicServiceRepository) Fetch(ctx context.Context, params *domain
 	query := querySelect + queryFilter + ` LIMIT ?,? `
 
 	res, err = m.fetch(ctx, query, params.Offset, params.PerPage)
-
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +123,7 @@ func (m *mysqlPublicServiceRepository) GetBySlug(ctx context.Context, slug strin
 }
 
 func (m *mysqlPublicServiceRepository) findOne(ctx context.Context, key string, value string) (res domain.PublicService, err error) {
-	query := fmt.Sprintf("%s WHERE %s=?", querySelect, key)
+	query := fmt.Sprintf("%s AND %s=?", querySelect, key)
 
 	list, err := m.fetch(ctx, query, value)
 	if err != nil {

--- a/core-service/src/modules/public-service/repository/mysql/mysql_public_service.go
+++ b/core-service/src/modules/public-service/repository/mysql/mysql_public_service.go
@@ -20,7 +20,7 @@ func NewMysqlPublicServiceRepository(Conn *sql.DB) domain.PublicServiceRepositor
 	return &mysqlPublicServiceRepository{Conn}
 }
 
-var querySelect = `SELECT id, name, description, unit, url, images, category, is_active, slug, excerpt, social_media, website, service_type, video, purposes, facilities, info, logo, created_at, updated_at FROM public_services`
+var querySelect = `SELECT id, name, description, unit, url, images, category, is_active, slug, excerpt, social_media, website, service_type, video, purposes, facilities, info, logo, created_at, updated_at FROM public_services WHERE 1=1`
 
 func (m *mysqlPublicServiceRepository) fetch(ctx context.Context, query string, args ...interface{}) (result []domain.PublicService, err error) {
 	rows, err := m.Conn.QueryContext(ctx, query, args...)
@@ -95,7 +95,8 @@ func (m *mysqlPublicServiceRepository) getLastUpdated(ctx context.Context, query
 }
 
 func (m *mysqlPublicServiceRepository) Fetch(ctx context.Context, params *domain.Request) (res []domain.PublicService, err error) {
-	query := querySelect + ` LIMIT ?,? `
+	queryFilter := filterPublicServiceQuery(params)
+	query := querySelect + queryFilter + ` LIMIT ?,? `
 
 	res, err = m.fetch(ctx, query, params.Offset, params.PerPage)
 

--- a/core-service/src/modules/public-service/repository/mysql/mysql_public_service_helper.go
+++ b/core-service/src/modules/public-service/repository/mysql/mysql_public_service_helper.go
@@ -1,0 +1,24 @@
+package mysql
+
+import (
+	"fmt"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+)
+
+/**
+ * this block of code is used to generate the query for the public service
+ */
+func filterPublicServiceQuery(params *domain.Request) string {
+	var queryFilter string
+
+	if params.Keyword != "" {
+		queryFilter += ` AND name LIKE '%` + params.Keyword + `%' `
+	}
+
+	if v, ok := params.Filters["service_type"]; ok && v != "" {
+		queryFilter = fmt.Sprintf(`%s AND service_type = "%s"`, queryFilter, v)
+	}
+
+	return queryFilter
+}


### PR DESCRIPTION
### Overview
Add (optional) filter by type and keywords

### Changes
- add custom params for `service_type`
- add mysql public service helper for optional filter

## Note
still seeing best practice for `optional filter`

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Menambahkan optional filter untuk service_type dan keywords layanan publik
participants: @rachadiannovansyah @sandisunandar99 @ayocodingit 