### PR TITLE
make api by slug is only for published news

### DIFF
--- a/core-service/src/domain/news.go
+++ b/core-service/src/domain/news.go
@@ -193,7 +193,7 @@ type NewsRepository interface {
 	FetchNewsBanner(ctx context.Context) (news []News, err error)
 	FetchNewsHeadline(ctx context.Context) (news []News, err error)
 	GetByID(ctx context.Context, id int64) (News, error)
-	GetBySlug(ctx context.Context, slug string) (News, error)
+	GetBySlug(ctx context.Context, slug string, is_live int) (News, error)
 	AddView(ctx context.Context, slug string) (err error)
 	AddShare(ctx context.Context, id int64) (err error)
 	Store(ctx context.Context, n *StoreNewsRequest) error

--- a/core-service/src/modules/news/repository/mysql/mysql_news.go
+++ b/core-service/src/modules/news/repository/mysql/mysql_news.go
@@ -195,8 +195,21 @@ func (m *mysqlNewsRepository) GetByID(ctx context.Context, id int64) (res domain
 	return m.findOne(ctx, "id", fmt.Sprintf("%v", id))
 }
 
-func (m *mysqlNewsRepository) GetBySlug(ctx context.Context, slug string) (res domain.News, err error) {
-	return m.findOne(ctx, "slug", slug)
+func (m *mysqlNewsRepository) GetBySlug(ctx context.Context, slug string, is_live int) (res domain.News, err error) {
+	query := fmt.Sprintf("%s AND slug=? AND is_live=?", querySelectNews)
+
+	list, err := m.fetch(ctx, query, slug, is_live)
+	if err != nil {
+		return domain.News{}, err
+	}
+
+	if len(list) > 0 {
+		res = list[0]
+	} else {
+		return res, domain.ErrNotFound
+	}
+
+	return
 }
 
 func (m *mysqlNewsRepository) AddView(ctx context.Context, slug string) (err error) {

--- a/core-service/src/modules/news/usecase/news_ucase.go
+++ b/core-service/src/modules/news/usecase/news_ucase.go
@@ -304,7 +304,7 @@ func (n *newsUsecase) fillRelatedNews(c context.Context, data []domain.NewsBanne
 
 func (n *newsUsecase) getDetail(ctx context.Context, key string, value interface{}) (res domain.News, err error) {
 	if key == "slug" {
-		res, err = n.newsRepo.GetBySlug(ctx, value.(string))
+		res, err = n.newsRepo.GetBySlug(ctx, value.(string), 1) // 1 is live
 	} else {
 		res, err = n.newsRepo.GetByID(ctx, value.(int64))
 	}
@@ -499,7 +499,7 @@ func (n *newsUsecase) GetViewsBySlug(c context.Context, slug string) (res domain
 	defer cancel()
 
 	err = n.newsRepo.AddView(ctx, slug)
-	res, err = n.newsRepo.GetBySlug(ctx, slug)
+	res, err = n.newsRepo.GetBySlug(ctx, slug, 1) // 1 is live
 	if err != nil {
 		logrus.Error(err)
 	}


### PR DESCRIPTION
### Overview
Adjust use case API endpoint get by slug
- No longer can view archived news by using API `news/slug/:slug`
- 1 is equal to published and 0 is equal unpublished/archived

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Penyesuaian use case Berita by slug
participants: @rachadiannovansyah @sandisunandar99 @rhmnmbr83 @ayocodingit @imamdev93 