### PR TITLE
Add meta property counts public service

### DIFF
--- a/core-service/src/domain/result.go
+++ b/core-service/src/domain/result.go
@@ -28,8 +28,9 @@ type MetaData struct {
 
 // CustomMetaData ..
 type CustomMetaData struct {
-	TotalCount  int64  `json:"total_count"`
+	TotalCount  int64  `json:"total_count"` // for dynamic count (this count affected by filters)
 	LastUpdated string `json:"last_updated"`
+	StaticCount int64  `json:"static_count,omitempty"` // for static count only
 }
 
 type MetaAggregations struct {

--- a/core-service/src/domain/service_public.go
+++ b/core-service/src/domain/service_public.go
@@ -192,6 +192,12 @@ type StorePublicService struct {
 	} `json:"faq" validate:"required"`
 }
 
+// ServicePublicResult ...
+type ServicePublicResult struct {
+	Data interface{} `json:"data"`
+	Meta interface{} `json:"meta"`
+}
+
 type ServicePublicRepository interface {
 	Fetch(ctx context.Context, params *Request) (sp []ServicePublic, err error)
 	MetaFetch(ctx context.Context, params *Request) (int64, string, int64, error)

--- a/core-service/src/domain/service_public.go
+++ b/core-service/src/domain/service_public.go
@@ -192,12 +192,6 @@ type StorePublicService struct {
 	} `json:"faq" validate:"required"`
 }
 
-// ServicePublicResult ...
-type ServicePublicResult struct {
-	Data interface{} `json:"data"`
-	Meta interface{} `json:"meta"`
-}
-
 type ServicePublicRepository interface {
 	Fetch(ctx context.Context, params *Request) (sp []ServicePublic, err error)
 	MetaFetch(ctx context.Context, params *Request) (int64, string, int64, error)

--- a/core-service/src/domain/service_public.go
+++ b/core-service/src/domain/service_public.go
@@ -194,14 +194,14 @@ type StorePublicService struct {
 
 type ServicePublicRepository interface {
 	Fetch(ctx context.Context, params *Request) (sp []ServicePublic, err error)
-	MetaFetch(ctx context.Context, params *Request) (int64, string, error)
+	MetaFetch(ctx context.Context, params *Request) (int64, string, int64, error)
 	GetBySlug(ctx context.Context, slug string) (ServicePublic, error)
 	Store(context.Context, StorePublicService, *sql.Tx) (err error)
 }
 
 type ServicePublicUsecase interface {
 	Fetch(ctx context.Context, params *Request) ([]ServicePublic, error)
-	MetaFetch(ctx context.Context, params *Request) (int64, string, error)
+	MetaFetch(ctx context.Context, params *Request) (int64, string, int64, error)
 	GetBySlug(ctx context.Context, slug string) (ServicePublic, error)
 	Store(context.Context, StorePublicService) error
 }

--- a/core-service/src/modules/service-public/delivery/http/service_public_handler.go
+++ b/core-service/src/modules/service-public/delivery/http/service_public_handler.go
@@ -49,15 +49,6 @@ func (h *ServicePublicHandler) Fetch(c echo.Context) error {
 		return err
 	}
 
-	// handled if no rows in result then res will provide empty arr
-	if total == 0 {
-		data := domain.ResultsData{
-			Data: []string{},
-		}
-
-		return c.JSON(http.StatusOK, data)
-	}
-
 	listServicePublic := []domain.ListServicePublicResponse{}
 	for _, row := range res {
 		// get struct response
@@ -66,7 +57,7 @@ func (h *ServicePublicHandler) Fetch(c echo.Context) error {
 		listServicePublic = append(listServicePublic, tmp)
 	}
 
-	data := domain.ResultsData{
+	data := domain.ServicePublicResult{
 		Data: listServicePublic,
 		Meta: &domain.CustomMetaData{
 			TotalCount:  total,

--- a/core-service/src/modules/service-public/delivery/http/service_public_handler.go
+++ b/core-service/src/modules/service-public/delivery/http/service_public_handler.go
@@ -43,7 +43,7 @@ func (h *ServicePublicHandler) Fetch(c echo.Context) error {
 		return err
 	}
 
-	total, lastUpdated, err := h.SPUsecase.MetaFetch(ctx, &params)
+	total, lastUpdated, staticCount, err := h.SPUsecase.MetaFetch(ctx, &params)
 
 	if err != nil {
 		return err
@@ -71,6 +71,7 @@ func (h *ServicePublicHandler) Fetch(c echo.Context) error {
 		Meta: &domain.CustomMetaData{
 			TotalCount:  total,
 			LastUpdated: lastUpdated,
+			StaticCount: staticCount,
 		},
 	}
 

--- a/core-service/src/modules/service-public/delivery/http/service_public_handler.go
+++ b/core-service/src/modules/service-public/delivery/http/service_public_handler.go
@@ -57,7 +57,7 @@ func (h *ServicePublicHandler) Fetch(c echo.Context) error {
 		listServicePublic = append(listServicePublic, tmp)
 	}
 
-	data := domain.ServicePublicResult{
+	data := domain.ResultsData{
 		Data: listServicePublic,
 		Meta: &domain.CustomMetaData{
 			TotalCount:  total,

--- a/core-service/src/modules/service-public/repository/mysql/mysql_service_public.go
+++ b/core-service/src/modules/service-public/repository/mysql/mysql_service_public.go
@@ -122,7 +122,7 @@ func (m *mysqlServicePublicRepository) Fetch(ctx context.Context, params *domain
 	return
 }
 
-func (m *mysqlServicePublicRepository) MetaFetch(ctx context.Context, params *domain.Request) (total int64, lastUpdated string, err error) {
+func (m *mysqlServicePublicRepository) MetaFetch(ctx context.Context, params *domain.Request) (total int64, lastUpdated string, staticCount int64, err error) {
 	binds := make([]interface{}, 0)
 	queryFilter := filterServicePublicQuery(params, &binds)
 
@@ -130,8 +130,10 @@ func (m *mysqlServicePublicRepository) MetaFetch(ctx context.Context, params *do
 
 	lastUpdated, err = m.getLastUpdated(ctx, ` SELECT updated_at FROM service_public ORDER BY updated_at DESC LIMIT 1`)
 
+	staticCount, _ = m.count(ctx, ` SELECT COUNT(1) FROM service_public s LEFT JOIN general_informations g ON s.general_information_id = g.id WHERE 1=1 AND g.category = ?`, params.Filters["category"].(string))
+
 	if err != nil {
-		return 0, "", err
+		return 0, "", 0, err
 	}
 
 	return

--- a/core-service/src/modules/service-public/usecase/service_public_ucase.go
+++ b/core-service/src/modules/service-public/usecase/service_public_ucase.go
@@ -105,15 +105,15 @@ func (u *servicePublicUsecase) fillGeneralInformation(c context.Context, data []
 	return data, nil
 }
 
-func (u *servicePublicUsecase) MetaFetch(c context.Context, params *domain.Request) (total int64, lastUpdated string, err error) {
+func (u *servicePublicUsecase) MetaFetch(c context.Context, params *domain.Request) (total int64, lastUpdated string, staticCount int64, err error) {
 
 	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
 	defer cancel()
 
-	total, lastUpdated, err = u.servicePublicRepo.MetaFetch(ctx, params)
+	total, lastUpdated, staticCount, err = u.servicePublicRepo.MetaFetch(ctx, params)
 
 	if err != nil {
-		return 0, "", err
+		return 0, "", 0, err
 	}
 
 	return


### PR DESCRIPTION
### Overview
- add `staticCount` property to meta data service public
- still provide propery counts not `null` when no data result

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Menambahkan mekanismes static count di layanan publik
participants: @rachadiannovansyah @ayocodingit 