### PR TITLE
add domain bucket name on media upload

### DIFF
--- a/core-service/src/domain/media.go
+++ b/core-service/src/domain/media.go
@@ -14,5 +14,5 @@ type MediaResponse struct {
 
 // MediaUsecase is an interface for media use cases
 type MediaUsecase interface {
-	Store(context.Context, *multipart.FileHeader, bytes.Buffer) (*MediaResponse, error)
+	Store(context.Context, *multipart.FileHeader, bytes.Buffer, string) (*MediaResponse, error)
 }

--- a/core-service/src/modules/media/delivery/http/media_handler.go
+++ b/core-service/src/modules/media/delivery/http/media_handler.go
@@ -33,7 +33,7 @@ func (h *MediaHandler) Store(c echo.Context) (err error) {
 		"events",
 		"public-service",
 		"units",
-		"featured_program",
+		"featured-program",
 		"informations",
 	}
 	domainExists, domainIndex := helpers.InArray(domain, domainBucketName)

--- a/core-service/src/modules/media/delivery/http/media_handler.go
+++ b/core-service/src/modules/media/delivery/http/media_handler.go
@@ -2,11 +2,13 @@ package http
 
 import (
 	"bytes"
-	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
-	"github.com/labstack/echo/v4"
-	"github.com/sirupsen/logrus"
 	"io"
 	"net/http"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
+	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
 )
 
 // MediaHandler ...
@@ -24,6 +26,22 @@ func NewMediaHandler(e *echo.Group, r *echo.Group, mu domain.MediaUsecase) {
 
 // Store will store the feedback by given request body
 func (h *MediaHandler) Store(c echo.Context) (err error) {
+	// validate for certain allowed bucket name of domain
+	domain := c.QueryParam("domain")
+	domainBucketName := []string{
+		"news",
+		"events",
+		"public-service",
+		"units",
+		"featured_program",
+		"informations",
+	}
+	domainExists, domainIndex := helpers.InArray(domain, domainBucketName)
+	domain = ""
+	if domainExists {
+		domain = domainBucketName[domainIndex] + "/"
+	}
+
 	// Source
 	file, err := c.FormFile("file")
 	if err != nil {
@@ -42,7 +60,7 @@ func (h *MediaHandler) Store(c echo.Context) (err error) {
 	}
 
 	ctx := c.Request().Context()
-	res, err := h.MUsecase.Store(ctx, file, buf)
+	res, err := h.MUsecase.Store(ctx, file, buf, domain)
 
 	if err != nil {
 		logrus.Fatal(err)

--- a/core-service/src/modules/media/usecase/media_ucase.go
+++ b/core-service/src/modules/media/usecase/media_ucase.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/config"
-	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/utils"
 	"mime/multipart"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/config"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/utils"
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
 )
@@ -39,10 +40,10 @@ func (u *mediaUsecase) newMediaResponse(fileName string, fileDownloadUri string,
 	}
 }
 
-func (u *mediaUsecase) Store(c context.Context, file *multipart.FileHeader, buf bytes.Buffer) (res *domain.MediaResponse, err error) {
+func (u *mediaUsecase) Store(c context.Context, file *multipart.FileHeader, buf bytes.Buffer, domain string) (res *domain.MediaResponse, err error) {
 	fileName := strings.Replace(fmt.Sprintf("%d-%s", time.Now().Unix(), file.Filename), " ", "-", -1) // fixme
 	fileSize := file.Size
-	filePath := u.config.AWS.Env + "/media/img/" + fileName
+	filePath := u.config.AWS.Env + "/media/img/" + domain + fileName
 	fileDownloadUri := u.config.AWS.Cloudfront + "/" + filePath
 
 	_, err = s3.New(u.conn.AWS).PutObject(&s3.PutObjectInput{


### PR DESCRIPTION
### Overview
- add the domain bucket name of the filepath
- validate to certain only can create and input on the allowed naming bucket

Example bucket domain public-service:
<img width="688" alt="image" src="https://user-images.githubusercontent.com/32012588/198935648-069acb24-6e09-43fd-9016-1d9da2bb0946.png">

Note:
The existing bucket of `news` is no root folder or "/"

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Menambahkan domain bucket name file path S3 Portal Jabar
participants: @rachadiannovansyah @sandisunandar99 @ayocodingit @rindibudiaramdhan 