### PR TITLE
Remove un-used news old-public api 

### DIFF
--- a/core-service/src/cmd/server/handler.go
+++ b/core-service/src/cmd/server/handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/utils"
 	"github.com/spf13/viper"
 
-	"github.com/getsentry/sentry-go"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 
@@ -55,13 +54,13 @@ func NewHandler(cfg *config.Config, apm *utils.Apm, u *Usecases) {
 	e.HTTPErrorHandler = ErrorHandler
 	middL := middl.InitMiddleware(cfg, apm.NewRelic)
 
-	e.Use(middL.NewRelic)
 	v1 := e.Group("/v1")
 	r := v1.Group("")
 	p := v1.Group("/public")
 
 	r.Use(middL.JWT)
 	e.Use(middleware.Logger())
+	e.Use(middL.NewRelic)
 	e.Use(nrecho.Middleware(apm.NewRelic))
 	e.Use(middleware.CORSWithConfig(cfg.Cors))
 
@@ -98,7 +97,7 @@ func ErrorHandler(err error, c echo.Context) {
 	if !ok {
 		report = echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	sentry.CaptureException(err)
+
 	c.Logger().Error(report)
 	c.JSON(report.Code, report)
 }

--- a/core-service/src/modules/news/delivery/http/news_handler.go
+++ b/core-service/src/modules/news/delivery/http/news_handler.go
@@ -42,12 +42,9 @@ func NewNewsHandler(e *echo.Group, r *echo.Group, us domain.NewsUsecase) {
 	r.GET("/news/:id", handler.GetByID, middl.CheckPermission(permManageNews))
 	r.PUT("/news/:id", handler.Update, middl.CheckPermission(permManageNews))
 	r.DELETE("/news/:id", handler.Delete, middl.CheckPermission(permManageNews))
-	r.PATCH("/news/:id/status", handler.UpdateStatus) // TO DO permission update status has multiple values
+	r.PATCH("/news/:id/status", handler.UpdateStatus)
 	r.GET("/news/tabs", handler.TabStatus)
-	e.GET("/news/slug/:slug", handler.GetBySlug)       // to be removed after frontend is ready
-	e.GET("/news/banner", handler.FetchNewsBanner)     // to be removed after frontend is ready
-	e.GET("/news/headline", handler.FetchNewsHeadline) // to be removed after frontend is ready
-	e.PATCH("/news/:id/share", handler.AddShare)       // to be removed after frontend is ready
+	e.PATCH("/news/:id/share", handler.AddShare)
 }
 
 // FetchNews will fetch the content based on given params
@@ -80,46 +77,6 @@ func (h *NewsHandler) FetchNews(c echo.Context) error {
 	copier.Copy(&listNewsRes, &listNews)
 
 	res := helpers.Paginate(c, listNewsRes, total, params)
-
-	return c.JSON(http.StatusOK, res)
-}
-
-// FetchNews will fetch the content based on given params
-func (h *NewsHandler) FetchNewsBanner(c echo.Context) error {
-
-	ctx := c.Request().Context()
-
-	listNews, err := h.CUsecase.FetchNewsBanner(ctx)
-
-	if err != nil {
-		return err
-	}
-
-	res := map[string]interface{}{
-		"data": listNews,
-	}
-
-	return c.JSON(http.StatusOK, res)
-}
-
-// FetchNewsHeadline ...
-func (h *NewsHandler) FetchNewsHeadline(c echo.Context) error {
-
-	ctx := c.Request().Context()
-
-	headlineNews, err := h.CUsecase.FetchNewsHeadline(ctx)
-
-	if err != nil {
-		return err
-	}
-
-	// Copy slice to slice
-	headlineNewsRes := []domain.NewsBanner{}
-	copier.Copy(&headlineNewsRes, &headlineNews)
-
-	res := map[string]interface{}{
-		"data": headlineNewsRes,
-	}
 
 	return c.JSON(http.StatusOK, res)
 }
@@ -162,23 +119,6 @@ func (h *NewsHandler) TabStatus(c echo.Context) (err error) {
 	}
 
 	return c.JSON(http.StatusOK, &domain.ResultData{Data: &tabs})
-}
-
-// GetBySlug will get article by given slug
-func (h *NewsHandler) GetBySlug(c echo.Context) error {
-	slug := c.Param("slug")
-	ctx := c.Request().Context()
-
-	news, err := h.CUsecase.GetBySlug(ctx, slug)
-	if err != nil {
-		return c.JSON(helpers.GetStatusCode(err), helpers.ResponseError{Message: err.Error()})
-	}
-
-	// Copy slice to slice
-	newsRes := domain.DetailNewsResponse{}
-	copier.Copy(&newsRes, &news)
-
-	return c.JSON(http.StatusOK, &domain.ResultData{Data: &newsRes})
 }
 
 // AddShare counter to share


### PR DESCRIPTION
### Overview
- remove un-used `sentry-capture`
- remove un-used old API public news
now has been declared on https://github.com/jabardigitalservice/portal-jabar-services/blob/main/core-service/src/modules/news/delivery/http/public_news_handler.go

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Remove un-used func of news
participants: @rachadiannovansyah @ayocodingit 