### PR TITLE
feat(pop up banner module): Add get by id endpoint & test

### DIFF
--- a/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
+++ b/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
@@ -44,6 +44,27 @@ func (_m *PopUpBannerRepository) Fetch(ctx context.Context, params *domain.Reque
 	return r0, r1, r2
 }
 
+// GetByID provides a mock function with given fields: ctx, id
+func (_m *PopUpBannerRepository) GetByID(ctx context.Context, id int64) (domain.PopUpBanner, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 domain.PopUpBanner
+	if rf, ok := ret.Get(0).(func(context.Context, int64) domain.PopUpBanner); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Get(0).(domain.PopUpBanner)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type mockConstructorTestingTNewPopUpBannerRepository interface {
 	mock.TestingT
 	Cleanup(func())

--- a/core-service/src/domain/pop_up_banner.go
+++ b/core-service/src/domain/pop_up_banner.go
@@ -29,6 +29,18 @@ type ListPopUpBannerResponse struct {
 	Status    string      `json:"status"`
 }
 
+type DetailPopUpBannerResponse struct {
+	ID          int64       `json:"id"`
+	Title       string      `json:"title"`
+	ButtonLabel string      `json:"button_label"`
+	Image       ImageBanner `json:"image,omitempty"`
+	Link        string      `json:"link"`
+	Status      string      `json:"status"`
+	Duration    int64       `json:"duration"`
+	StartDate   *time.Time  `json:"start_date"`
+	UpdateAt    time.Time   `json:"updated_at"`
+}
+
 type ImageBanner struct {
 	Desktop string `json:"desktop,omitempty"`
 	Mobile  string `json:"mobile,omitempty"`
@@ -36,8 +48,10 @@ type ImageBanner struct {
 
 type PopUpBannerUsecase interface {
 	Fetch(ctx context.Context, auth *JwtCustomClaims, params *Request) (res []PopUpBanner, total int64, err error)
+	GetByID(ctx context.Context, id int64) (res PopUpBanner, err error)
 }
 
 type PopUpBannerRepository interface {
 	Fetch(ctx context.Context, params *Request) (res []PopUpBanner, total int64, err error)
+	GetByID(ctx context.Context, id int64) (res PopUpBanner, err error)
 }

--- a/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner_test.go
+++ b/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner_test.go
@@ -73,6 +73,61 @@ func TestFetch(t *testing.T) {
 
 	// make an assertions using testify
 	assert.NotNil(t, list)
-	// assert.Equal(t, len(list), total)
+	assert.NoError(t, err)
+}
+
+func TestGetByID(t *testing.T) {
+	// create sql mock db
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf(`an error ‘%s’ was not expected when opening a stub  
+        database connection`, err)
+	}
+	defer db.Close()
+
+	// create mock data from struct
+	mockStruct := domain.PopUpBanner{}
+	err = faker.FakeData(&mockStruct)
+	if err != nil {
+		t.Fatalf(`an error ‘%s’ was not expected when faking detail service public struct`, err)
+	}
+
+	// create rows to be created from a sql driver.Value slice
+	rows := sqlmock.NewRows([]string{
+		"id",
+		"title",
+		"button_label",
+		"image",
+		"link",
+		"status",
+		"duration",
+		"start_date",
+		"end_date",
+		"created_at",
+		"updated_at",
+	}).
+		AddRow(
+			mockStruct.ID,
+			mockStruct.Title,
+			mockStruct.ButtonLabel,
+			helpers.GetStringFromObject(mockStruct.Image),
+			mockStruct.Link,
+			mockStruct.Status,
+			mockStruct.Duration,
+			mockStruct.StartDate,
+			mockStruct.EndDate,
+			mockStruct.CreatedAt,
+			mockStruct.UpdatedAt,
+		)
+
+	query := `SELECT id, title, button_label, image, link, status, duration, start_date, end_date, created_at, updated_at FROM pop_up_banners WHERE 1=1`
+
+	mock.ExpectQuery(query).WillReturnRows(rows)
+	pb := pRepo.NewMysqlPopUpBannerRepository(db)
+
+	obj, err := pb.GetByID(context.TODO(), int64(1))
+
+	// make an assertions using testify
+	assert.NotNil(t, obj)
 	assert.NoError(t, err)
 }

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
@@ -34,3 +34,15 @@ func (u *popUpBannerUsecase) Fetch(c context.Context, auth *domain.JwtCustomClai
 
 	return
 }
+
+func (u *popUpBannerUsecase) GetByID(c context.Context, id int64) (res domain.PopUpBanner, err error) {
+	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
+	defer cancel()
+
+	res, err = u.popUpBannerRepo.GetByID(ctx, id)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
@@ -87,3 +87,27 @@ func TestFetch(t *testing.T) {
 		assert.Len(t, list, int(total))
 	})
 }
+
+func TestGetByID(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// mock expectation being called
+		ts.popUpBannerRepo.On("GetByID", mock.Anything, mock.Anything).Return(mockStruct, nil).Once()
+		obj, err := usecase.GetByID(context.TODO(), int64(mockStruct.ID))
+
+		// assertions
+		assert.Equal(t, mockStruct, obj)
+		assert.NoError(t, err)
+
+		ts.popUpBannerRepo.AssertExpectations(t)
+		ts.popUpBannerRepo.AssertCalled(t, "GetByID", mock.Anything, mock.AnythingOfType("int64"))
+	})
+
+	t.Run("error-occurred", func(t *testing.T) {
+		// mock expectation being called
+		ts.popUpBannerRepo.On("GetByID", mock.Anything, mock.AnythingOfType("int64")).Return(domain.PopUpBanner{}, domain.ErrInternalServerError).Once()
+		_, err := usecase.GetByID(context.TODO(), mockStruct.ID)
+
+		// assertions
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
### Overview
- feat(pop up banner module): Add get by id endpoint
- Add use case test and repository test

### Related to the ticket
https://app.clickup.com/t/860pjr61u

## Attachments
Figma's:
<img width="758" alt="image" src="https://user-images.githubusercontent.com/32012588/214520919-af5ecfab-0f97-4a7b-a373-7ceff46fbaf2.png">

Response:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/32012588/214521078-124e0895-e39f-40ef-b8fd-fc44d3f0e22b.png">


Test result:
<img width="854" alt="image" src="https://user-images.githubusercontent.com/32012588/214520656-8fdfd9d7-2894-4914-8857-bb29b0b2b0d5.png">



cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Membuat API get by id & unit test
participants: @rachadiannovansyah @ayocodingit @rhmnmbr @iqbal167 