### PR TITLE
feat(media):api-delete-object-s3

### DIFF
--- a/core-service/src/domain/media.go
+++ b/core-service/src/domain/media.go
@@ -12,7 +12,13 @@ type MediaResponse struct {
 	Size            int64  `json:"size"`
 }
 
+type DeleteMediaRequest struct {
+	Domain string `json:"domain"`
+	Key    string `json:"key"`
+}
+
 // MediaUsecase is an interface for media use cases
 type MediaUsecase interface {
 	Store(context.Context, *multipart.FileHeader, bytes.Buffer, string) (*MediaResponse, error)
+	Delete(ctx context.Context, body *DeleteMediaRequest) (err error)
 }

--- a/core-service/src/modules/media/delivery/http/media_handler.go
+++ b/core-service/src/modules/media/delivery/http/media_handler.go
@@ -86,7 +86,7 @@ func (h *MediaHandler) Delete(c echo.Context) (err error) {
 	}
 
 	res := domain.MessageResponse{
-		Message: "succesfully deleted file from s3 bucket.",
+		Message: "succesfully deleted file from cloud storage.",
 	}
 
 	return c.JSON(http.StatusCreated, res)

--- a/core-service/src/modules/media/delivery/http/media_handler.go
+++ b/core-service/src/modules/media/delivery/http/media_handler.go
@@ -22,6 +22,7 @@ func NewMediaHandler(e *echo.Group, r *echo.Group, mu domain.MediaUsecase) {
 		MUsecase: mu,
 	}
 	r.POST("/media/upload", handler.Store)
+	r.DELETE("/media/delete", handler.Delete)
 }
 
 // Store will store the feedback by given request body
@@ -35,6 +36,8 @@ func (h *MediaHandler) Store(c echo.Context) (err error) {
 		"units",
 		"featured-program",
 		"informations",
+		"pop-up-banners",
+		"infographic-banners",
 	}
 	domainExists, domainIndex := helpers.InArray(domain, domainBucketName)
 	domain = ""
@@ -64,6 +67,26 @@ func (h *MediaHandler) Store(c echo.Context) (err error) {
 
 	if err != nil {
 		logrus.Fatal(err)
+	}
+
+	return c.JSON(http.StatusCreated, res)
+}
+
+// Delete will delete the object S3 based on key name
+func (h *MediaHandler) Delete(c echo.Context) (err error) {
+	ctx := c.Request().Context()
+	reqBody := new(domain.DeleteMediaRequest)
+	if err = c.Bind(&reqBody); err != nil {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
+	}
+
+	err = h.MUsecase.Delete(ctx, reqBody)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	res := domain.MessageResponse{
+		Message: "succesfully deleted file from s3 bucket.",
 	}
 
 	return c.JSON(http.StatusCreated, res)

--- a/core-service/src/modules/media/usecase/media_ucase.go
+++ b/core-service/src/modules/media/usecase/media_ucase.go
@@ -59,3 +59,18 @@ func (u *mediaUsecase) Store(c context.Context, file *multipart.FileHeader, buf 
 
 	return u.newMediaResponse(fileName, fileDownloadUri, fileSize), err
 }
+
+func (u *mediaUsecase) Delete(c context.Context, body *domain.DeleteMediaRequest) (err error) {
+	filePath := u.config.AWS.Env + "/media/img/" + body.Domain + body.Key
+
+	_, err = s3.New(u.conn.AWS).DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(u.config.AWS.Bucket),
+		Key:    aws.String(filePath),
+	})
+
+	if err != nil {
+		return
+	}
+
+	return
+}


### PR DESCRIPTION
### Overview
- feat(media):api-delete-object-s3

### Related to the ticket
https://app.clickup.com/t/860pjr5xj

## Note
Because we're using versioning on S3 Bucket, so deleteObject only marks the object with the `Delete Marker` object type.

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Create API media to delete objects from S3
participants: @rachadiannovansyah @rhmnmbr @rindibudiaramdhan @ayocodingit @iqbal167 