### PR TITLE
feat(pop up banner module): Add delete endpoint

### DIFF
--- a/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
+++ b/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
@@ -14,6 +14,20 @@ type PopUpBannerRepository struct {
 	mock.Mock
 }
 
+// Delete provides a mock function with given fields: ctx, id
+func (_m *PopUpBannerRepository) Delete(ctx context.Context, id int64) error {
+	ret := _m.Called(ctx, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Fetch provides a mock function with given fields: ctx, params
 func (_m *PopUpBannerRepository) Fetch(ctx context.Context, params *domain.Request) ([]domain.PopUpBanner, int64, error) {
 	ret := _m.Called(ctx, params)

--- a/core-service/src/domain/pop_up_banner.go
+++ b/core-service/src/domain/pop_up_banner.go
@@ -68,10 +68,12 @@ type PopUpBannerUsecase interface {
 	Fetch(ctx context.Context, auth *JwtCustomClaims, params *Request) (res []PopUpBanner, total int64, err error)
 	GetByID(ctx context.Context, id int64) (res PopUpBanner, err error)
 	Store(ctx context.Context, auth *JwtCustomClaims, body StorePopUpBannerRequest) (err error)
+	Delete(ctx context.Context, id int64) (err error)
 }
 
 type PopUpBannerRepository interface {
 	Fetch(ctx context.Context, params *Request) (res []PopUpBanner, total int64, err error)
 	GetByID(ctx context.Context, id int64) (res PopUpBanner, err error)
 	Store(ctx context.Context, body StorePopUpBannerRequest) (err error)
+	Delete(ctx context.Context, id int64) (err error)
 }

--- a/core-service/src/modules/media/delivery/http/media_handler.go
+++ b/core-service/src/modules/media/delivery/http/media_handler.go
@@ -89,5 +89,5 @@ func (h *MediaHandler) Delete(c echo.Context) (err error) {
 		Message: "succesfully deleted file from cloud storage.",
 	}
 
-	return c.JSON(http.StatusCreated, res)
+	return c.JSON(http.StatusOK, res)
 }

--- a/core-service/src/modules/pop-up-banner/delivery/http/pop_up_banner_handler.go
+++ b/core-service/src/modules/pop-up-banner/delivery/http/pop_up_banner_handler.go
@@ -29,6 +29,7 @@ func NewPopUpBannerHandler(r *echo.Group, ucase domain.PopUpBannerUsecase, apm *
 	r.GET("/pop-up-banners", handler.Fetch)
 	r.GET("/pop-up-banners/:id", handler.GetByID)
 	r.POST("/pop-up-banners", handler.Store)
+	r.DELETE("/pop-up-banners/:id", handler.Delete)
 }
 
 // Fetch will fetch the service-public
@@ -131,6 +132,24 @@ func (h *PopUpBannerHandler) Store(c echo.Context) (err error) {
 	}
 
 	return c.JSON(http.StatusCreated, res)
+}
+
+// Delete will delete the pop-up-banner by given id
+func (h *PopUpBannerHandler) Delete(c echo.Context) (err error) {
+	reqID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return c.JSON(http.StatusNotFound, domain.ErrNotFound.Error())
+	}
+
+	id := int64(reqID)
+	ctx := c.Request().Context()
+
+	err = h.PUsecase.Delete(ctx, id)
+	if err != nil {
+		return c.JSON(helpers.GetStatusCode(err), helpers.ResponseError{Message: err.Error()})
+	}
+
+	return c.NoContent(http.StatusNoContent)
 }
 
 func isRequestValid(ps interface{}) (bool, error) {

--- a/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
+++ b/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
@@ -142,3 +142,28 @@ func (m *mysqlPopUpBannerRepository) Store(ctx context.Context, body domain.Stor
 
 	return
 }
+
+func (m *mysqlPopUpBannerRepository) Delete(ctx context.Context, id int64) (err error) {
+	query := "DELETE FROM pop_up_banners WHERE id = ?"
+	stmt, err := m.Conn.PrepareContext(ctx, query)
+	if err != nil {
+		return
+	}
+
+	res, err := stmt.ExecContext(ctx, id)
+	if err != nil {
+		return
+	}
+
+	rowAffected, err := res.RowsAffected()
+	if err != nil {
+		return
+	}
+
+	if rowAffected != 1 {
+		err = fmt.Errorf("Weird Behavior. Total Affected: %d", rowAffected)
+		return
+	}
+
+	return
+}

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
@@ -57,3 +57,14 @@ func (u *popUpBannerUsecase) Store(c context.Context, au *domain.JwtCustomClaims
 
 	return
 }
+
+func (u *popUpBannerUsecase) Delete(c context.Context, id int64) (err error) {
+	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
+	defer cancel()
+
+	if err = u.popUpBannerRepo.Delete(ctx, id); err != nil {
+		return
+	}
+
+	return
+}

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
@@ -137,3 +137,25 @@ func TestStore(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestDelete(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// mock expectation being called
+		ts.popUpBannerRepo.On("Delete", mock.Anything, mock.AnythingOfType("int64")).Return(nil).Once()
+		err := usecase.Delete(context.TODO(), mockStruct.ID)
+
+		// assertions
+		assert.NoError(t, err)
+		ts.popUpBannerRepo.AssertExpectations(t)
+		ts.popUpBannerRepo.AssertCalled(t, "Delete", mock.Anything, mock.AnythingOfType("int64"))
+	})
+
+	t.Run("error-occurred", func(t *testing.T) {
+		// mock expectation being called
+		ts.popUpBannerRepo.On("Delete", mock.Anything, mock.AnythingOfType("int64")).Return(domain.ErrInternalServerError).Once()
+		err := usecase.Delete(context.TODO(), mockStruct.ID)
+
+		// assertions
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
### Overview
feat(pop up banner module): Add delete endpoint
- add use case test delete API

### Related to the ticket
https://app.clickup.com/t/860pjr637

## Attachments
Test Result
<img width="917" alt="image" src="https://user-images.githubusercontent.com/32012588/215667220-eb3012a3-40f8-468b-953d-a40a2864cebb.png">


cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Create API endpoint delete pop-up-banner module CMS Portal Jabar
participants: @rachadiannovansyah @iqbal167  