### PR TITLE
feat(pop-up-banners):add patch status update api

### DIFF
--- a/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
+++ b/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
@@ -93,6 +93,20 @@ func (_m *PopUpBannerRepository) Store(ctx context.Context, body domain.StorePop
 	return r0
 }
 
+// UpdateStatus provides a mock function with given fields: ctx, id, status
+func (_m *PopUpBannerRepository) UpdateStatus(ctx context.Context, id int64, status string) error {
+	ret := _m.Called(ctx, id, status)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string) error); ok {
+		r0 = rf(ctx, id, status)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewPopUpBannerRepository interface {
 	mock.TestingT
 	Cleanup(func())

--- a/core-service/src/domain/pop_up_banner.go
+++ b/core-service/src/domain/pop_up_banner.go
@@ -54,6 +54,10 @@ type StorePopUpBannerRequest struct {
 	Image        ImageBanner          `json:"image" validate:"required"`
 }
 
+type UpdateStatusPopUpBannerRequest struct {
+	Status string `json:"status" validate:"required,eq=ACTIVE|eq=NON-ACTIVE"`
+}
+
 type CustomButtonlabel struct {
 	Label string `json:"label"`
 	Link  string `json:"link"`
@@ -69,6 +73,7 @@ type PopUpBannerUsecase interface {
 	GetByID(ctx context.Context, id int64) (res PopUpBanner, err error)
 	Store(ctx context.Context, auth *JwtCustomClaims, body StorePopUpBannerRequest) (err error)
 	Delete(ctx context.Context, id int64) (err error)
+	UpdateStatus(ctx context.Context, id int64, status string) (err error)
 }
 
 type PopUpBannerRepository interface {
@@ -76,4 +81,5 @@ type PopUpBannerRepository interface {
 	GetByID(ctx context.Context, id int64) (res PopUpBanner, err error)
 	Store(ctx context.Context, body StorePopUpBannerRequest) (err error)
 	Delete(ctx context.Context, id int64) (err error)
+	UpdateStatus(ctx context.Context, id int64, status string) (err error)
 }

--- a/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
+++ b/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
@@ -167,3 +167,18 @@ func (m *mysqlPopUpBannerRepository) Delete(ctx context.Context, id int64) (err 
 
 	return
 }
+
+func (m *mysqlPopUpBannerRepository) UpdateStatus(ctx context.Context, id int64, status string) (err error) {
+	query := `UPDATE pop_up_banners SET status = ? WHERE id = ?`
+	stmt, err := m.Conn.PrepareContext(ctx, query)
+	if err != nil {
+		return
+	}
+
+	_, err = stmt.ExecContext(ctx,
+		status,
+		id,
+	)
+
+	return
+}

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
@@ -68,3 +68,11 @@ func (u *popUpBannerUsecase) Delete(c context.Context, id int64) (err error) {
 
 	return
 }
+
+func (n *popUpBannerUsecase) UpdateStatus(ctx context.Context, ID int64, status string) (err error) {
+	if err = n.popUpBannerRepo.UpdateStatus(ctx, ID, status); err != nil {
+		return
+	}
+
+	return
+}

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
@@ -159,3 +159,30 @@ func TestDelete(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestUpdateStatus(t *testing.T) {
+	var mockUpdateStruct domain.UpdateStatusPopUpBannerRequest
+	err = faker.FakeData(&mockUpdateStruct)
+
+	t.Run("success", func(t *testing.T) {
+		// mock expectation being called
+		ts.popUpBannerRepo.On("UpdateStatus", mock.Anything, mock.AnythingOfType("int64"), mock.Anything).Return(nil).Once()
+
+		err := usecase.UpdateStatus(context.TODO(), mockStruct.ID, mockUpdateStruct.Status)
+
+		// assertions
+		assert.NoError(t, err)
+		ts.popUpBannerRepo.AssertCalled(t, "UpdateStatus", mock.Anything, mock.AnythingOfType("int64"), mock.Anything)
+	})
+
+	t.Run("errror-occurred", func(t *testing.T) {
+		// mock expectation being called
+		ts.popUpBannerRepo.On("UpdateStatus", mock.Anything, mock.AnythingOfType("int64"), mock.Anything).Return(domain.ErrInternalServerError).Once()
+
+		err := usecase.UpdateStatus(context.TODO(), mockStruct.ID, "UN-ACTIVE")
+
+		// assertions
+		assert.Error(t, err)
+	})
+
+}


### PR DESCRIPTION
### Overview
- feat(pop-up-banners): add patch status update API
- add use case test update status API

### Related to the ticket
https://app.clickup.com/t/860pjr637

## Attachments
Test Result
<img width="757" alt="image" src="https://user-images.githubusercontent.com/32012588/215699184-75d96dc3-9107-41c4-af2c-5a0f4a6b1453.png">


cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Create API endpoint partial update status pop up banner module CMS Portal Jabar
participants: @rachadiannovansyah @rhmnmbr @iqbal167 