### PR TITLE
feat(pop-up-banners): add sort by filter and set default sort

### DIFF
--- a/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
+++ b/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
@@ -73,6 +73,12 @@ func (m *mysqlPopUpBannerRepository) Fetch(ctx context.Context, params *domain.R
 	binds := make([]interface{}, 0)
 	queryFilter := filterPopUpBannerQuery(params, &binds)
 
+	if params.SortBy != "" {
+		queryFilter += ` ORDER BY ` + params.SortBy + ` ` + params.SortOrder
+	} else {
+		queryFilter += ` ORDER BY created_at DESC`
+	}
+
 	// get count of data
 	total, _ = m.count(ctx, ` SELECT COUNT(1) FROM pop_up_banners WHERE 1=1 `+queryFilter, binds...)
 

--- a/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
+++ b/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
@@ -73,11 +73,11 @@ func (m *mysqlPopUpBannerRepository) Fetch(ctx context.Context, params *domain.R
 	binds := make([]interface{}, 0)
 	queryFilter := filterPopUpBannerQuery(params, &binds)
 
+	defaultSort := ` ORDER BY status, created_at DESC`
 	if params.SortBy != "" {
-		queryFilter += ` ORDER BY ` + params.SortBy + ` ` + params.SortOrder
-	} else {
-		queryFilter += ` ORDER BY created_at DESC`
+		defaultSort = ` ORDER BY ` + params.SortBy + ` ` + params.SortOrder
 	}
+	queryFilter += defaultSort
 
 	// get count of data
 	total, _ = m.count(ctx, ` SELECT COUNT(1) FROM pop_up_banners WHERE 1=1 `+queryFilter, binds...)


### PR DESCRIPTION
### Overview
- feat(pop-up-banners): add sort by filter and set default sort
- rules of default sort is by `status` then by `created_at` fields

### Related to the ticket
https://app.clickup.com/t/860pjr5x8

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Add default sort CMS pop-up banner
participants: @rachadiannovansyah @rindibudiaramdhan @rhmnmbr @indraprasetya154 @samudra-ajri @imamdev93 @iqbal167 