### PR TITLE
fix(pop-up-banners):rules of patch status by list

### DIFF
--- a/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
+++ b/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
@@ -14,6 +14,27 @@ type PopUpBannerRepository struct {
 	mock.Mock
 }
 
+// CheckStatus provides a mock function with given fields: ctx, status
+func (_m *PopUpBannerRepository) CheckStatus(ctx context.Context, status string) (int64, error) {
+	ret := _m.Called(ctx, status)
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(context.Context, string) int64); ok {
+		r0 = rf(ctx, status)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, status)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Delete provides a mock function with given fields: ctx, id
 func (_m *PopUpBannerRepository) Delete(ctx context.Context, id int64) error {
 	ret := _m.Called(ctx, id)

--- a/core-service/src/domain/pop_up_banner.go
+++ b/core-service/src/domain/pop_up_banner.go
@@ -85,4 +85,5 @@ type PopUpBannerRepository interface {
 	Delete(ctx context.Context, id int64) (err error)
 	UpdateStatus(ctx context.Context, id int64, status string) (err error)
 	Update(ctx context.Context, id int64, body *StorePopUpBannerRequest) (err error)
+	CheckStatus(ctx context.Context, status string) (id int64, err error)
 }

--- a/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
+++ b/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -73,7 +74,7 @@ func (m *mysqlPopUpBannerRepository) Fetch(ctx context.Context, params *domain.R
 	binds := make([]interface{}, 0)
 	queryFilter := filterPopUpBannerQuery(params, &binds)
 
-	defaultSort := ` ORDER BY status, created_at DESC`
+	defaultSort := ` ORDER BY status, updated_at DESC`
 	if params.SortBy != "" {
 		defaultSort = ` ORDER BY ` + params.SortBy + ` ` + params.SortOrder
 	}
@@ -175,7 +176,7 @@ func (m *mysqlPopUpBannerRepository) Delete(ctx context.Context, id int64) (err 
 }
 
 func (m *mysqlPopUpBannerRepository) UpdateStatus(ctx context.Context, id int64, status string) (err error) {
-	query := `UPDATE pop_up_banners SET status = ? WHERE id = ?`
+	query := `UPDATE pop_up_banners SET status = ?, updated_at = ? WHERE id = ?`
 	stmt, err := m.Conn.PrepareContext(ctx, query)
 	if err != nil {
 		return
@@ -183,6 +184,7 @@ func (m *mysqlPopUpBannerRepository) UpdateStatus(ctx context.Context, id int64,
 
 	_, err = stmt.ExecContext(ctx,
 		status,
+		time.Now(),
 		id,
 	)
 
@@ -191,7 +193,7 @@ func (m *mysqlPopUpBannerRepository) UpdateStatus(ctx context.Context, id int64,
 
 func (m *mysqlPopUpBannerRepository) Update(ctx context.Context, id int64, body *domain.StorePopUpBannerRequest) (err error) {
 	query := `UPDATE pop_up_banners SET title=?, button_label=?, link=?, image=?, duration=?,
-	start_date=?, end_date=? WHERE id=?`
+	start_date=?, end_date=?, updated_at=? WHERE id=?`
 
 	stmt, err := m.Conn.PrepareContext(ctx, query)
 	if err != nil {
@@ -206,6 +208,7 @@ func (m *mysqlPopUpBannerRepository) Update(ctx context.Context, id int64, body 
 		body.Scheduler.Duration,
 		body.Scheduler.StartDate,
 		helpers.ConvertStringToTime(body.Scheduler.StartDate).AddDate(0, 0, int(body.Scheduler.Duration)),
+		time.Now(),
 		id,
 	)
 

--- a/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
+++ b/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
@@ -119,6 +119,19 @@ func (m *mysqlPopUpBannerRepository) GetByID(ctx context.Context, id int64) (res
 	return
 }
 
+func (m *mysqlPopUpBannerRepository) CheckStatus(ctx context.Context, status string) (id int64, err error) {
+	query := `SELECT id FROM pop_up_banners WHERE status = ? LIMIT 1`
+	err = m.Conn.QueryRowContext(ctx, query, status).Scan(
+		&id,
+	)
+
+	if err != nil {
+		err = domain.ErrNotFound
+	}
+
+	return
+}
+
 func (m *mysqlPopUpBannerRepository) Store(ctx context.Context, body domain.StorePopUpBannerRequest) (err error) {
 	query := `INSERT pop_up_banners SET title=?, button_label=?, link=?, image=?, duration=?,
 		start_date=?, end_date=?`

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
@@ -70,6 +70,20 @@ func (u *popUpBannerUsecase) Delete(c context.Context, id int64) (err error) {
 }
 
 func (n *popUpBannerUsecase) UpdateStatus(ctx context.Context, ID int64, status string) (err error) {
+	// add rules only can avail one of is active pop up banner
+	resId, err := n.popUpBannerRepo.CheckStatus(ctx, "ACTIVE")
+	if err != nil {
+		return
+	}
+
+	// if there's one, then disable the existing pop up banner
+	if resId != 0 {
+		err = n.popUpBannerRepo.UpdateStatus(ctx, resId, "NON-ACTIVE")
+		if err != nil {
+			return
+		}
+	}
+
 	if err = n.popUpBannerRepo.UpdateStatus(ctx, ID, status); err != nil {
 		return
 	}

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
@@ -166,18 +166,21 @@ func TestUpdateStatus(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		// mock expectation being called
-		ts.popUpBannerRepo.On("UpdateStatus", mock.Anything, mock.AnythingOfType("int64"), mock.Anything).Return(nil).Once()
+		ts.popUpBannerRepo.On("CheckStatus", mock.Anything, mock.AnythingOfType("string")).Return(mockStruct.ID, nil).Once()
+		ts.popUpBannerRepo.On("UpdateStatus", mock.Anything, mock.AnythingOfType("int64"), mock.Anything).Return(nil)
 
 		err := usecase.UpdateStatus(context.TODO(), mockStruct.ID, mockUpdateStruct.Status)
 
 		// assertions
 		assert.NoError(t, err)
+		ts.popUpBannerRepo.AssertCalled(t, "CheckStatus", mock.Anything, mock.AnythingOfType("string"))
 		ts.popUpBannerRepo.AssertCalled(t, "UpdateStatus", mock.Anything, mock.AnythingOfType("int64"), mock.Anything)
 	})
 
-	t.Run("errror-occurred", func(t *testing.T) {
+	t.Run("error-occurred", func(t *testing.T) {
 		// mock expectation being called
-		ts.popUpBannerRepo.On("UpdateStatus", mock.Anything, mock.AnythingOfType("int64"), mock.Anything).Return(domain.ErrInternalServerError).Once()
+		ts.popUpBannerRepo.On("CheckStatus", mock.Anything, mock.AnythingOfType("string")).Return(mockStruct.ID+1, domain.ErrNotFound).Once()
+		ts.popUpBannerRepo.On("UpdateStatus", mock.Anything, mock.AnythingOfType("int64"), mock.Anything).Return(domain.ErrNotFound)
 
 		err := usecase.UpdateStatus(context.TODO(), mockStruct.ID, "UN-ACTIVE")
 


### PR DESCRIPTION
### Overview
- fix(pop-up-banners): rules of patch status by list
- updated time of update process

### Related to the ticket
https://app.clickup.com/t/860pjr5yx

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Add rules of patching status on list pop-up banner CMS Portal Jabar
participants: @rachadiannovansyah @rhmnmbr @ayocodingit 