### PR TITLE
feat(pop-up-banner): create api live banner on landing page

### DIFF
--- a/core-service/src/cmd/server/handler.go
+++ b/core-service/src/cmd/server/handler.go
@@ -99,6 +99,7 @@ func NewHandler(cfg *config.Config, apm *utils.Apm, u *Usecases, logger utils.Lo
 	_publicServiceHttpDelivery.NewPublicServiceHandler(v1, p, u.PublicServiceUsecase)
 	_visitorHttpDelivery.NewCounterVisitorHandler(p, u.VisitorUsecase)
 	_popUpBannerDelivery.NewPopUpBannerHandler(r, u.PopUpBannerUsecase, apm)
+	_popUpBannerDelivery.NewPublicPopUpBanner(p, u.PopUpBannerUsecase, apm)
 
 	log.Fatal(e.Start(viper.GetString("APP_ADDRESS")))
 }

--- a/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
+++ b/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
@@ -93,6 +93,27 @@ func (_m *PopUpBannerRepository) GetByID(ctx context.Context, id int64) (domain.
 	return r0, r1
 }
 
+// LiveBanner provides a mock function with given fields: ctx
+func (_m *PopUpBannerRepository) LiveBanner(ctx context.Context) (domain.PopUpBanner, error) {
+	ret := _m.Called(ctx)
+
+	var r0 domain.PopUpBanner
+	if rf, ok := ret.Get(0).(func(context.Context) domain.PopUpBanner); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(domain.PopUpBanner)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Store provides a mock function with given fields: ctx, body
 func (_m *PopUpBannerRepository) Store(ctx context.Context, body domain.StorePopUpBannerRequest) error {
 	ret := _m.Called(ctx, body)

--- a/core-service/src/domain/pop_up_banner.go
+++ b/core-service/src/domain/pop_up_banner.go
@@ -79,6 +79,7 @@ type PopUpBannerUsecase interface {
 	Delete(ctx context.Context, id int64) (err error)
 	UpdateStatus(ctx context.Context, id int64, body *UpdateStatusPopUpBannerRequest) (err error)
 	Update(ctx context.Context, auth *JwtCustomClaims, id int64, body *StorePopUpBannerRequest) (err error)
+	LiveBanner(ctx context.Context) (res PopUpBanner, err error)
 }
 
 type PopUpBannerRepository interface {
@@ -89,4 +90,5 @@ type PopUpBannerRepository interface {
 	UpdateStatus(ctx context.Context, id int64, body *UpdateStatusPopUpBannerRequest) (err error)
 	DeactiveStatus(ctx context.Context) (err error)
 	Update(ctx context.Context, id int64, body *StorePopUpBannerRequest) (err error)
+	LiveBanner(ctx context.Context) (res PopUpBanner, err error)
 }

--- a/core-service/src/modules/pop-up-banner/delivery/http/public_pop_up_banner_handler.go
+++ b/core-service/src/modules/pop-up-banner/delivery/http/public_pop_up_banner_handler.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/utils"
+)
+
+// PublicPopUpBanner ...
+type PublicPopUpBanner struct {
+	PUsecase domain.PopUpBannerUsecase
+	apm      *utils.Apm
+}
+
+// NewPublicPopUpBanner will create a new PublicPopUpBanner
+func NewPublicPopUpBanner(e *echo.Group, ucase domain.PopUpBannerUsecase, apm *utils.Apm) {
+	handler := &PublicPopUpBanner{
+		PUsecase: ucase,
+		apm:      apm,
+	}
+
+	e.GET("/pop-up-banners/live", handler.LiveBanner)
+}
+
+// LiveBanner will get pop up banner with active status and is_live is 1
+func (h *PublicPopUpBanner) LiveBanner(c echo.Context) error {
+	ctx := c.Request().Context()
+	data, err := h.PUsecase.LiveBanner(ctx)
+	if err != nil {
+		return c.JSON(helpers.GetStatusCode(err), helpers.ResponseError{Message: err.Error()})
+	}
+
+	// re-presenting responses
+	res := domain.DetailPopUpBannerResponse{
+		ID:          data.ID,
+		Title:       data.Title,
+		ButtonLabel: data.ButtonLabel,
+		Link:        data.Link,
+		Status:      data.Status,
+		Duration:    data.Duration,
+		StartDate:   data.StartDate,
+		EndDate:     data.EndDate,
+		UpdateAt:    data.UpdatedAt,
+	}
+
+	helpers.GetObjectFromString(data.Image.String, &res.Image)
+
+	return c.JSON(http.StatusOK, &domain.ResultData{Data: &res})
+}

--- a/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
+++ b/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
@@ -250,3 +250,26 @@ func (m *mysqlPopUpBannerRepository) Update(ctx context.Context, id int64, body 
 
 	return
 }
+
+func (m *mysqlPopUpBannerRepository) LiveBanner(ctx context.Context) (res domain.PopUpBanner, err error) {
+	query := querySelect + " AND status = ? AND is_live = ? LIMIT 1"
+	err = m.Conn.QueryRowContext(ctx, query, "ACTIVE", 1).Scan(
+		&res.ID,
+		&res.Title,
+		&res.ButtonLabel,
+		&res.Image,
+		&res.Link,
+		&res.Status,
+		&res.Duration,
+		&res.StartDate,
+		&res.EndDate,
+		&res.CreatedAt,
+		&res.UpdatedAt,
+	)
+
+	if err != nil {
+		err = domain.ErrNotFound
+	}
+
+	return
+}

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
@@ -100,3 +100,15 @@ func (n *popUpBannerUsecase) Update(ctx context.Context, au *domain.JwtCustomCla
 
 	return
 }
+
+func (u *popUpBannerUsecase) LiveBanner(c context.Context) (res domain.PopUpBanner, err error) {
+	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
+	defer cancel()
+
+	res, err = u.popUpBannerRepo.LiveBanner(ctx)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
@@ -228,13 +228,12 @@ func TestLiveBanner(t *testing.T) {
 		assert.Equal(t, mockStruct, obj)
 		assert.NoError(t, err)
 
-		ts.popUpBannerRepo.AssertExpectations(t)
 		ts.popUpBannerRepo.AssertCalled(t, "LiveBanner", mock.Anything)
 	})
 
 	t.Run("error-occurred", func(t *testing.T) {
 		// mock expectation being called
-		ts.popUpBannerRepo.On("LiveBanner", mock.Anything).Return(domain.PopUpBanner{}, domain.ErrInternalServerError).Once()
+		ts.popUpBannerRepo.On("LiveBanner", mock.Anything).Return(domain.PopUpBanner{}, domain.ErrNotFound).Once()
 		_, err := usecase.LiveBanner(context.TODO())
 
 		// assertions

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
@@ -217,3 +217,27 @@ func TestUpdate(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestLiveBanner(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// mock expectation being called
+		ts.popUpBannerRepo.On("LiveBanner", mock.Anything).Return(mockStruct, nil).Once()
+		obj, err := usecase.LiveBanner(context.TODO())
+
+		// assertions
+		assert.Equal(t, mockStruct, obj)
+		assert.NoError(t, err)
+
+		ts.popUpBannerRepo.AssertExpectations(t)
+		ts.popUpBannerRepo.AssertCalled(t, "LiveBanner", mock.Anything)
+	})
+
+	t.Run("error-occurred", func(t *testing.T) {
+		// mock expectation being called
+		ts.popUpBannerRepo.On("LiveBanner", mock.Anything).Return(domain.PopUpBanner{}, domain.ErrInternalServerError).Once()
+		_, err := usecase.LiveBanner(context.TODO())
+
+		// assertions
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
### Overview
- feat(pop-up-banner): create a live banner on the landing page
- no need for restricted middleware on the endpoint

### Related to the ticket
https://app.clickup.com/t/860pjr61u

## Attachment 
Result when the job is running:
![image](https://user-images.githubusercontent.com/32012588/217432375-70ae234e-a3b5-4c88-a471-2e16a588a652.png)

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: Create API Endpoint public live pop-up banner
participants: @rachadiannovansyah @rindibudiaramdhan @rhmnmbr 