### PR TITLE
[portal-jabarprov] feat(service-worker): set `now()` on every job updated process

### DIFF
--- a/service-worker/src/job/pop_up_banner_deactive_job.go
+++ b/service-worker/src/job/pop_up_banner_deactive_job.go
@@ -14,7 +14,8 @@ func PopUpBannerDeactivateJob(conn *utils.Conn, cfg *config.Config) {
 	// deactivate banner
 	deactivateQuery := `UPDATE pop_up_banners 
 	SET status = 'NON-ACTIVE',
-	is_live = 0
+	is_live = 0,
+	updated_at = now()
 	WHERE status = 'ACTIVE'
 	AND end_date < NOW()`
 


### PR DESCRIPTION
### Overview
- feat(service-worker:) set `now()` on every job updated process

### Related to the ticket
https://app.clickup.com/t/860pjr61u

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: update worker update time process CMS portal jabar
participants: @rachadiannovansyah @indraprasetya154 @samudra-ajri @iqbal167 