### PR TITLE
[portal-jabarprov] feat(pop-up-banner): add flag `is_scheduled` on scheduler process

### DIFF
--- a/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
+++ b/core-service/src/domain/mocks/repositories/PopUpBannerRepositoryMocks.go
@@ -115,11 +115,11 @@ func (_m *PopUpBannerRepository) LiveBanner(ctx context.Context) (domain.PopUpBa
 }
 
 // Store provides a mock function with given fields: ctx, body
-func (_m *PopUpBannerRepository) Store(ctx context.Context, body domain.StorePopUpBannerRequest) error {
+func (_m *PopUpBannerRepository) Store(ctx context.Context, body *domain.StorePopUpBannerRequest) error {
 	ret := _m.Called(ctx, body)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, domain.StorePopUpBannerRequest) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *domain.StorePopUpBannerRequest) error); ok {
 		r0 = rf(ctx, body)
 	} else {
 		r0 = ret.Error(0)

--- a/core-service/src/domain/pop_up_banner.go
+++ b/core-service/src/domain/pop_up_banner.go
@@ -96,8 +96,10 @@ type CustomButtonlabel struct {
 }
 
 type SchedulerPopUpBanner struct {
-	Duration  int64   `json:"duration"`
-	StartDate *string `json:"start_date"`
+	Duration    int64   `json:"duration"`
+	StartDate   *string `json:"start_date"`
+	IsScheduled int64   `json:"is_scheduled"`
+	Status      string  `json:"status"`
 }
 
 type LiveBannerResponse struct {
@@ -116,7 +118,7 @@ type LiveBannerResponse struct {
 type PopUpBannerUsecase interface {
 	Fetch(ctx context.Context, auth *JwtCustomClaims, params *Request) (res []PopUpBanner, total int64, err error)
 	GetByID(ctx context.Context, id int64) (res PopUpBanner, err error)
-	Store(ctx context.Context, auth *JwtCustomClaims, body StorePopUpBannerRequest) (err error)
+	Store(ctx context.Context, auth *JwtCustomClaims, body *StorePopUpBannerRequest) (err error)
 	Delete(ctx context.Context, id int64) (err error)
 	UpdateStatus(ctx context.Context, id int64, body *UpdateStatusPopUpBannerRequest) (err error)
 	Update(ctx context.Context, auth *JwtCustomClaims, id int64, body *StorePopUpBannerRequest) (err error)
@@ -127,7 +129,7 @@ type PopUpBannerUsecase interface {
 type PopUpBannerRepository interface {
 	Fetch(ctx context.Context, params *Request) (res []PopUpBanner, total int64, err error)
 	GetByID(ctx context.Context, id int64) (res PopUpBanner, err error)
-	Store(ctx context.Context, body StorePopUpBannerRequest) (err error)
+	Store(ctx context.Context, body *StorePopUpBannerRequest) (err error)
 	Delete(ctx context.Context, id int64) (err error)
 	UpdateStatus(ctx context.Context, id int64, body *UpdateStatusPopUpBannerRequest) (err error)
 	DeactiveStatus(ctx context.Context) (err error)

--- a/core-service/src/modules/pop-up-banner/delivery/http/pop_up_banner_handler.go
+++ b/core-service/src/modules/pop-up-banner/delivery/http/pop_up_banner_handler.go
@@ -137,7 +137,7 @@ func (h *PopUpBannerHandler) Store(c echo.Context) (err error) {
 	mapstructure.Decode(c.Get("auth:user"), &auth)
 
 	ctx := c.Request().Context()
-	err = h.PUsecase.Store(ctx, &auth, *req)
+	err = h.PUsecase.Store(ctx, &auth, req)
 	if err != nil {
 		return err
 	}

--- a/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
+++ b/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
@@ -234,7 +234,7 @@ func (m *mysqlPopUpBannerRepository) DeactiveStatus(ctx context.Context) (err er
 
 func (m *mysqlPopUpBannerRepository) Update(ctx context.Context, id int64, body *domain.StorePopUpBannerRequest) (err error) {
 	query := `UPDATE pop_up_banners SET title=?, button_label=?, link=?, image=?, duration=?,
-	start_date=?, end_date=?, updated_at=? WHERE id=?`
+	start_date=?, end_date=?, status=?, updated_at=? WHERE id=?`
 
 	stmt, err := m.Conn.PrepareContext(ctx, query)
 	if err != nil {
@@ -249,6 +249,7 @@ func (m *mysqlPopUpBannerRepository) Update(ctx context.Context, id int64, body 
 		body.Scheduler.Duration,
 		body.Scheduler.StartDate,
 		helpers.ConvertStringToTime(body.Scheduler.StartDate).AddDate(0, 0, int(body.Scheduler.Duration)),
+		body.Scheduler.Status,
 		time.Now(),
 		id,
 	)

--- a/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
+++ b/core-service/src/modules/pop-up-banner/repository/mysql/mysql_pop_up_banner.go
@@ -135,9 +135,9 @@ func (m *mysqlPopUpBannerRepository) CheckStatus(ctx context.Context, status str
 	return
 }
 
-func (m *mysqlPopUpBannerRepository) Store(ctx context.Context, body domain.StorePopUpBannerRequest) (err error) {
+func (m *mysqlPopUpBannerRepository) Store(ctx context.Context, body *domain.StorePopUpBannerRequest) (err error) {
 	query := `INSERT pop_up_banners SET title=?, button_label=?, link=?, image=?, duration=?,
-		start_date=?, end_date=?, updated_at=?, created_at=?`
+		start_date=?, end_date=?, status=?, updated_at=?, created_at=?`
 	stmt, err := m.Conn.PrepareContext(ctx, query)
 	if err != nil {
 		return
@@ -151,6 +151,7 @@ func (m *mysqlPopUpBannerRepository) Store(ctx context.Context, body domain.Stor
 		body.Scheduler.Duration,
 		body.Scheduler.StartDate,
 		helpers.ConvertStringToTime(body.Scheduler.StartDate).AddDate(0, 0, int(body.Scheduler.Duration)),
+		body.Scheduler.Status,
 		time.Now(),
 		time.Now(),
 	)

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
@@ -51,9 +51,14 @@ func (u *popUpBannerUsecase) GetByID(c context.Context, id int64) (res domain.Po
 	return
 }
 
-func (u *popUpBannerUsecase) Store(c context.Context, au *domain.JwtCustomClaims, body domain.StorePopUpBannerRequest) (err error) {
+func (u *popUpBannerUsecase) Store(c context.Context, au *domain.JwtCustomClaims, body *domain.StorePopUpBannerRequest) (err error) {
 	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
 	defer cancel()
+
+	body.Scheduler.Status = "NON-ACTIVE"
+	if body.Scheduler.IsScheduled == 1 { // 1 is mean true
+		body.Scheduler.Status = "ACTIVE"
+	}
 
 	if err = u.popUpBannerRepo.Store(ctx, body); err != nil {
 		return

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase.go
@@ -55,6 +55,7 @@ func (u *popUpBannerUsecase) Store(c context.Context, au *domain.JwtCustomClaims
 	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
 	defer cancel()
 
+	// set flag if use scheduler
 	body.Scheduler.Status = "NON-ACTIVE"
 	if body.Scheduler.IsScheduled == 1 { // 1 is mean true
 		body.Scheduler.Status = "ACTIVE"
@@ -103,6 +104,12 @@ func (n *popUpBannerUsecase) UpdateStatus(ctx context.Context, ID int64, body *d
 }
 
 func (n *popUpBannerUsecase) Update(ctx context.Context, au *domain.JwtCustomClaims, ID int64, body *domain.StorePopUpBannerRequest) (err error) {
+	// set flag if use scheduler
+	body.Scheduler.Status = "NON-ACTIVE"
+	if body.Scheduler.IsScheduled == 1 { // 1 is mean true
+		body.Scheduler.Status = "ACTIVE"
+	}
+
 	if err = n.popUpBannerRepo.Update(ctx, ID, body); err != nil {
 		return
 	}

--- a/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
+++ b/core-service/src/modules/pop-up-banner/usecase/pop_up_banner_ucase_test.go
@@ -119,7 +119,7 @@ func TestStore(t *testing.T) {
 		// mock expectation being called
 		ts.popUpBannerRepo.On("Store", mock.Anything, mock.Anything).Return(nil).Once()
 
-		err := usecase.Store(context.TODO(), &mockJwtStruct, mockRequest)
+		err := usecase.Store(context.TODO(), &mockJwtStruct, &mockRequest)
 
 		// assertions
 		assert.NoError(t, err)
@@ -131,7 +131,7 @@ func TestStore(t *testing.T) {
 		// mock expectation being called
 		ts.popUpBannerRepo.On("Store", mock.Anything, mock.Anything).Return(domain.ErrInternalServerError).Once()
 
-		err := usecase.Store(context.TODO(), &mockJwtStruct, mockRequest)
+		err := usecase.Store(context.TODO(), &mockJwtStruct, &mockRequest)
 
 		// assertions
 		assert.Error(t, err)


### PR DESCRIPTION
### Overview
- feat(pop-up-banner): add flag `is_scheduled` on scheduler process
- parse the status with the default value is "NON-ACTIVE"

### Related to the ticket
https://app.clickup.com/t/860pjr61u

### Test result
![image](https://user-images.githubusercontent.com/32012588/218376218-5478b78e-5167-41f2-a744-e87b2d73568c.png)

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: add the flag `is_scheduled` on the scheduler process 
participants: @rachadiannovansyah @ayocodingit @rhmnmbr 