### PR TITLE
core-svc-feat(publications): add list api endpoint of publication

### DIFF
--- a/core-service/src/domain/master_data_publication.go
+++ b/core-service/src/domain/master_data_publication.go
@@ -17,12 +17,40 @@ type MasterDataPublication struct {
 }
 
 type DefaultInformation struct {
+	MdsID             int64     `json:"mds_id"`
+	OpdName           string    `json:"opd_name"`
+	ServiceForm       string    `json:"form"`
+	ServiceName       string    `json:"name"`
+	ProgramName       string    `json:"program_name"`
+	Description       string    `json:"description"`
+	ServiceUser       string    `json:"user"`
+	PortalCategory    string    `json:"portal_category"`
+	OperationalStatus string    `json:"operational_status"`
+	Technical         string    `json:"technical"`
+	Benefits          MdsObject `json:"benefits"`
+	Facilities        MdsObject `json:"facilities"`
+	Slug              string    `json:"slug"`
 }
 
 type ServiceDescription struct {
+	Cover              CoverPublication       `json:"cover"`
+	Images             []DetailMetaDataImage  `json:"images"`
+	TermsAndConditions MdsObjectCover         `json:"terms_and_conditions"`
+	ServiceProcedures  MdsObjectCover         `json:"service_procedures"`
+	ServiceFee         string                 `json:"service_fee"`
+	OperationalTimes   []OperationalTimeMds   `json:"operational_times"`
+	HotlineNumber      string                 `json:"hotline_number"`
+	HotlineMail        string                 `json:"hotline_mail"`
+	InfoGraphics       PublicationInfographic `json:"infographics"`
+	Locations          []LocationMds          `json:"locations"`
+	Application        MdsApplication         `json:"application"`
+	Links              []LinkMds              `json:"links"`
+	SocialMedia        []SocialMediaMds       `json:"social_media"`
 }
 
 type PublicationInformation struct {
+	Keywords []string       `json:"keywords"`
+	FAQ      PublicationFAQ `json:"faq"`
 }
 
 type StoreMasterDataPublication struct {
@@ -70,9 +98,11 @@ type PublicationFAQ struct {
 }
 type MasterDataPublicationUsecase interface {
 	Store(ctx context.Context, body *StoreMasterDataPublication) (err error)
+	Fetch(ctx context.Context, au *JwtCustomClaims, params *Request) (res []MasterDataPublication, total int64, err error)
 }
 
 type MasterDataPublicationRepository interface {
 	Store(ctx context.Context, body *StoreMasterDataPublication) (err error)
 	GetTx(context.Context) (*sql.Tx, error)
+	Fetch(ctx context.Context, params *Request) (res []MasterDataPublication, total int64, err error)
 }

--- a/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication.go
+++ b/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/helpers"
+	"github.com/sirupsen/logrus"
 )
 
 type mysqlMdpRepository struct {
@@ -17,6 +18,16 @@ type mysqlMdpRepository struct {
 func NewMysqlMasterDataPublicationRepository(Conn *sql.DB) domain.MasterDataPublicationRepository {
 	return &mysqlMdpRepository{Conn}
 }
+
+var querySelectJoin = `SELECT pub.id, pub.mds_id, ms.service_name, units.name, ms.service_user, ms.technical, pub.updated_at, pub.status
+FROM masterdata_publications pub
+LEFT JOIN masterdata_services mds
+ON pub.mds_id = mds.id
+LEFT JOIN main_services ms
+ON mds.main_service = ms.id
+LEFT JOIN units
+ON ms.opd_name = units.id
+WHERE 1=1`
 
 func (m *mysqlMdpRepository) Store(ctx context.Context, body *domain.StoreMasterDataPublication) (err error) {
 	query := `INSERT masterdata_publications SET mds_id=?, portal_category=?, slug=?, cover=?, images=?, infographics=?, keywords=?, faq=?, status=?, created_at=?, updated_at=?`
@@ -51,5 +62,70 @@ func (m *mysqlMdpRepository) GetTx(ctx context.Context) (tx *sql.Tx, err error) 
 	if err != nil {
 		return
 	}
+	return
+}
+
+func (m *mysqlMdpRepository) fetch(ctx context.Context, query string, args ...interface{}) (result []domain.MasterDataPublication, err error) {
+	rows, err := m.Conn.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	result = make([]domain.MasterDataPublication, 0)
+	for rows.Next() {
+		pub := domain.MasterDataPublication{}
+		err = rows.Scan(
+			&pub.ID,
+			&pub.DefaultInformation.MdsID,
+			&pub.DefaultInformation.ServiceName,
+			&pub.DefaultInformation.OpdName,
+			&pub.DefaultInformation.ServiceUser,
+			&pub.DefaultInformation.Technical,
+			&pub.UpdatedAt,
+			&pub.Status,
+		)
+
+		if err != nil {
+			logrus.Error(err)
+			return nil, err
+		}
+
+		result = append(result, pub)
+	}
+
+	return result, nil
+}
+
+func (m *mysqlMdpRepository) count(ctx context.Context, query string, args ...interface{}) (total int64, err error) {
+	err = m.Conn.QueryRow(query, args...).Scan(&total)
+	if err != nil {
+		logrus.Error(err)
+		return
+	}
+
+	return total, nil
+}
+
+func (m *mysqlMdpRepository) Fetch(ctx context.Context, params *domain.Request) (res []domain.MasterDataPublication, total int64, err error) {
+	binds := make([]interface{}, 0)
+	query := filterPublicationQuery(params, &binds)
+
+	if params.SortBy != "" {
+		query += ` ORDER BY ` + params.SortBy + ` ` + params.SortOrder
+	} else {
+		query += ` ORDER BY updated_at DESC`
+	}
+
+	total, _ = m.count(ctx, ` SELECT COUNT(1) FROM masterdata_publications pub WHERE 1=1 `+query, binds...)
+	query = querySelectJoin + query + ` LIMIT ?,? `
+
+	binds = append(binds, params.Offset, params.PerPage)
+
+	res, err = m.fetch(ctx, query, binds...)
+
+	if err != nil {
+		return nil, 0, err
+	}
+
 	return
 }

--- a/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication_helper.go
+++ b/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication_helper.go
@@ -1,0 +1,27 @@
+package mysql
+
+import (
+	"fmt"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+)
+
+/**
+ * this block of code is used to generate the query for the news
+ * need to be refactored later to be more generic and reduce the code complexity (go generic tech debt)
+ */
+func filterPublicationQuery(params *domain.Request, binds *[]interface{}) string {
+	var query string
+
+	if params.Keyword != "" {
+		*binds = append(*binds, `%`+params.Keyword+`%`)
+		query = fmt.Sprintf(`%s AND ms.service_name LIKE ?`, query)
+	}
+
+	if params.Filters["status"] != "" {
+		*binds = append(*binds, params.Filters["status"])
+		query = fmt.Sprintf(`%s AND pub.status = ?`, query)
+	}
+
+	return query
+}

--- a/core-service/src/modules/master-data-publication/usecase/publication_ucase.go
+++ b/core-service/src/modules/master-data-publication/usecase/publication_ucase.go
@@ -75,3 +75,16 @@ func (n *masterDataPublicationUsecase) Store(ctx context.Context, body *domain.S
 
 	return
 }
+
+func (n *masterDataPublicationUsecase) Fetch(c context.Context, au *domain.JwtCustomClaims, params *domain.Request) (
+	res []domain.MasterDataPublication, total int64, err error) {
+	ctx, cancel := context.WithTimeout(c, n.contextTimeout)
+	defer cancel()
+
+	res, total, err = n.mdpRepo.Fetch(ctx, params)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return
+}


### PR DESCRIPTION
### Overview
add API endpoint list master data `publications` 
- path: `/v1//master-data-publications`
- method: `GET`

## Available params:
- `status`: for a filter by status (`PUBLISH` or `ARCHIVE`)
- `q`: for filtering data by keywords

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: create API endpoint publication list module
participants: @rachadiannovansyah @muhamadabduh @ayocodingit 