### PR TITLE
core-svc-feat(publications): add api delete publication

### DIFF
--- a/core-service/src/domain/master_data_publication.go
+++ b/core-service/src/domain/master_data_publication.go
@@ -99,10 +99,12 @@ type PublicationFAQ struct {
 type MasterDataPublicationUsecase interface {
 	Store(ctx context.Context, body *StoreMasterDataPublication) (err error)
 	Fetch(ctx context.Context, au *JwtCustomClaims, params *Request) (res []MasterDataPublication, total int64, err error)
+	Delete(ctx context.Context, id int64) (err error)
 }
 
 type MasterDataPublicationRepository interface {
 	Store(ctx context.Context, body *StoreMasterDataPublication) (err error)
 	GetTx(context.Context) (*sql.Tx, error)
 	Fetch(ctx context.Context, params *Request) (res []MasterDataPublication, total int64, err error)
+	Delete(ctx context.Context, id int64) (err error)
 }

--- a/core-service/src/modules/master-data-publication/delivery/http/publication_handler.go
+++ b/core-service/src/modules/master-data-publication/delivery/http/publication_handler.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/go-playground/validator"
 	"github.com/labstack/echo/v4"
@@ -25,6 +26,7 @@ func NewMasterDataPublicationHandler(r *echo.Group, sp domain.MasterDataPublicat
 	}
 	r.POST("/master-data-publications", handler.Store)
 	r.GET("/master-data-publications", handler.Fetch)
+	r.DELETE("/master-data-publications/:id", handler.Delete)
 }
 
 func (h *MasterDataPublicationHandler) Store(c echo.Context) (err error) {
@@ -105,4 +107,22 @@ func (h *MasterDataPublicationHandler) Fetch(c echo.Context) error {
 	res := helpers.Paginate(c, pubRes, total, params)
 
 	return c.JSON(http.StatusOK, res)
+}
+
+// Delete will delete the master-data-publications by given id
+func (h *MasterDataPublicationHandler) Delete(c echo.Context) (err error) {
+	reqID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return c.JSON(http.StatusNotFound, domain.ErrNotFound.Error())
+	}
+
+	id := int64(reqID)
+	ctx := c.Request().Context()
+
+	err = h.MdpUcase.Delete(ctx, id)
+	if err != nil {
+		return c.JSON(helpers.GetStatusCode(err), helpers.ResponseError{Message: err.Error()})
+	}
+
+	return c.NoContent(http.StatusNoContent)
 }

--- a/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication.go
+++ b/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication.go
@@ -129,3 +129,37 @@ func (m *mysqlMdpRepository) Fetch(ctx context.Context, params *domain.Request) 
 
 	return
 }
+
+func (m *mysqlMdpRepository) Delete(ctx context.Context, id int64) (err error) {
+	query := "DELETE FROM masterdata_publications WHERE id = ?"
+	stmt, err := m.Conn.PrepareContext(ctx, query)
+	if err != nil {
+		return
+	}
+
+	res, err := stmt.ExecContext(ctx, id)
+	if err != nil {
+		return
+	}
+
+	err = m.rowsAffected(res)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (m *mysqlMdpRepository) rowsAffected(res sql.Result) (err error) {
+	rowAffected, err := res.RowsAffected()
+	if err != nil {
+		return
+	}
+
+	if rowAffected != 1 {
+		logrus.Error(err)
+		return
+	}
+
+	return
+}

--- a/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication_test.go
+++ b/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication_test.go
@@ -1,0 +1,28 @@
+package mysql_test
+
+import (
+	"context"
+	"testing"
+
+	mdpRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/master-data-publication/repository/mysql"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+func TestDelete(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	query := "DELETE FROM masterdata_publications WHERE id = ?"
+
+	prep := mock.ExpectPrepare(query)
+	prep.ExpectExec().WithArgs(12).WillReturnResult(sqlmock.NewResult(12, 1))
+
+	a := mdpRepo.NewMysqlMasterDataPublicationRepository(db)
+
+	num := int64(12)
+	err = a.Delete(context.TODO(), num)
+	assert.NoError(t, err)
+}

--- a/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication_test.go
+++ b/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/bxcodec/faker"
+	"github.com/go-faker/faker/v4"
 	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
 	mdpRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/master-data-publication/repository/mysql"
 	"github.com/stretchr/testify/assert"

--- a/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication_test.go
+++ b/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication_test.go
@@ -4,25 +4,33 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bxcodec/faker"
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
 	mdpRepo "github.com/jabardigitalservice/portal-jabar-services/core-service/src/modules/master-data-publication/repository/mysql"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
+
+var mockStruct domain.MasterDataPublication
 
 func TestDelete(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
+	err = faker.FakeData(&mockStruct)
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when generate fake data", err)
+	}
 
 	query := "DELETE FROM masterdata_publications WHERE id = ?"
 
 	prep := mock.ExpectPrepare(query)
-	prep.ExpectExec().WithArgs(12).WillReturnResult(sqlmock.NewResult(12, 1))
+	prep.ExpectExec().WithArgs(mockStruct.ID).WillReturnResult(sqlmock.NewResult(mockStruct.ID, 1))
 
 	a := mdpRepo.NewMysqlMasterDataPublicationRepository(db)
 
-	num := int64(12)
+	num := int64(mockStruct.ID)
 	err = a.Delete(context.TODO(), num)
 	assert.NoError(t, err)
 }

--- a/core-service/src/modules/master-data-publication/usecase/publication_ucase.go
+++ b/core-service/src/modules/master-data-publication/usecase/publication_ucase.go
@@ -88,3 +88,14 @@ func (n *masterDataPublicationUsecase) Fetch(c context.Context, au *domain.JwtCu
 
 	return
 }
+
+func (u *masterDataPublicationUsecase) Delete(c context.Context, id int64) (err error) {
+	ctx, cancel := context.WithTimeout(c, u.contextTimeout)
+	defer cancel()
+
+	if err = u.mdpRepo.Delete(ctx, id); err != nil {
+		return
+	}
+
+	return
+}


### PR DESCRIPTION
### Overview
add API endpoint delete master data `publications` 
- path: `/v1/master-data-publications/:id`
- method: `DELETE`

## Attachments
<img width="757" alt="image" src="https://user-images.githubusercontent.com/32012588/231963851-b9155c37-1ee1-4740-a1d3-e74fb6463776.png">


cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: create API endpoint delete publication
participants: @rachadiannovansyah @rhmnmbr @ayocodingit @iqbal167 