### PR TITLE
core-svc-feat(publications): add api endpoint update publication

### DIFF
--- a/core-service/src/domain/master_data_publication.go
+++ b/core-service/src/domain/master_data_publication.go
@@ -156,6 +156,7 @@ type MasterDataPublicationUsecase interface {
 	Delete(ctx context.Context, id int64) (err error)
 	GetByID(ctx context.Context, ID int64) (res MasterDataPublication, err error)
 	TabStatus(context.Context) ([]TabStatusResponse, error)
+	Update(ctx context.Context, body *StoreMasterDataPublication, ID int64) (err error)
 }
 
 type MasterDataPublicationRepository interface {
@@ -165,4 +166,5 @@ type MasterDataPublicationRepository interface {
 	Delete(ctx context.Context, id int64) (err error)
 	GetByID(ctx context.Context, ID int64) (res MasterDataPublication, err error)
 	TabStatus(context.Context) ([]TabStatusResponse, error)
+	Update(ctx context.Context, body *StoreMasterDataPublication, ID int64) (err error)
 }

--- a/core-service/src/modules/master-data-publication/delivery/http/publication_handler.go
+++ b/core-service/src/modules/master-data-publication/delivery/http/publication_handler.go
@@ -30,6 +30,7 @@ func NewMasterDataPublicationHandler(r *echo.Group, sp domain.MasterDataPublicat
 	r.DELETE("/master-data-publications/:id", handler.Delete)
 	r.GET("/master-data-publications/:id", handler.GetByID)
 	r.GET("/master-data-publications/tabs", handler.TabStatus)
+	r.PUT("/master-data-publications/:id", handler.Update)
 }
 
 func (h *MasterDataPublicationHandler) Store(c echo.Context) (err error) {
@@ -177,4 +178,29 @@ func (h *MasterDataPublicationHandler) TabStatus(c echo.Context) (err error) {
 	}
 
 	return c.JSON(http.StatusOK, &domain.ResultData{Data: &tabs})
+}
+
+func (h *MasterDataPublicationHandler) Update(c echo.Context) (err error) {
+	ctx := c.Request().Context()
+	reqID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return c.JSON(http.StatusNotFound, domain.ErrNotFound.Error())
+	}
+
+	ID := int64(reqID)
+	body, err := h.bindRequest(c)
+	if err != nil {
+		return
+	}
+
+	err = h.MdpUcase.Update(ctx, body, ID)
+	if err != nil {
+		return c.JSON(helpers.GetStatusCode(err), helpers.ResponseError{Message: err.Error()})
+	}
+
+	result := map[string]interface{}{
+		"message": "UPDATED",
+	}
+
+	return c.JSON(http.StatusOK, result)
 }

--- a/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication.go
+++ b/core-service/src/modules/master-data-publication/repository/mysql/mysql_publication.go
@@ -269,3 +269,33 @@ func (m *mysqlMdpRepository) fetchTabs(ctx context.Context, query string, args .
 
 	return result, nil
 }
+
+func (m *mysqlMdpRepository) Update(ctx context.Context, body *domain.StoreMasterDataPublication, ID int64) (err error) {
+	query := `UPDATE masterdata_publications SET mds_id=?, portal_category=?, slug=?, cover=?, images=?, infographics=?, keywords=?, faq=?, status=?, created_at=?, updated_at=?
+		WHERE id=?`
+	stmt, err := m.Conn.PrepareContext(ctx, query)
+	if err != nil {
+		return
+	}
+
+	_, err = stmt.ExecContext(ctx,
+		body.DefaultInformation.MdsID,
+		body.DefaultInformation.PortalCategory,
+		body.DefaultInformation.Slug,
+		helpers.GetStringFromObject(body.ServiceDescription.Cover),
+		helpers.GetStringFromObject(body.ServiceDescription.Images),
+		helpers.GetStringFromObject(body.ServiceDescription.InfoGraphics),
+		helpers.GetStringFromObject(body.AdditionalInformation.Keywords),
+		helpers.GetStringFromObject(body.AdditionalInformation.FAQ),
+		body.Status,
+		time.Now(),
+		time.Now(),
+		ID,
+	)
+
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/core-service/src/modules/master-data-publication/usecase/publication_ucase.go
+++ b/core-service/src/modules/master-data-publication/usecase/publication_ucase.go
@@ -119,3 +119,54 @@ func (n *masterDataPublicationUsecase) TabStatus(ctx context.Context) (res []dom
 	}
 	return
 }
+
+func (n *masterDataPublicationUsecase) Update(ctx context.Context, body *domain.StoreMasterDataPublication, pubID int64) (err error) {
+	// begin db transaction
+	tx, err := n.mdpRepo.GetTx(ctx)
+	if err != nil {
+		return
+	}
+
+	// get id existing mds
+	mds, err := n.mdsRepo.GetByID(ctx, body.DefaultInformation.MdsID)
+	if err != nil {
+		return errors.New("Your Master Data ID Is Not Exist.")
+	}
+
+	mdsBody := domain.StoreMasterDataService{}
+	mdsBody.Services.Information.Benefits = body.DefaultInformation.Benefits
+	mdsBody.Services.Information.Facilities = body.DefaultInformation.Facilities
+	mdsBody.Services.ServiceDetail.TermsAndConditions = body.ServiceDescription.TermsAndConditions
+	mdsBody.Services.ServiceDetail.ServiceProcedures = body.ServiceDescription.ServiceProcedures
+
+	// completed existing main_service domain fields
+	if err = n.msRepo.UpdateFromPublication(ctx, mds.MainService.ID, &mdsBody, tx); err != nil {
+		return
+	}
+
+	// completed existing applications domain fields
+	mdsBody.Application.Name = body.ServiceDescription.Application.Name
+	mdsBody.Application.Status = body.ServiceDescription.Application.Status
+	mdsBody.Application.Features = body.ServiceDescription.Application.Features
+	mdsBody.Application.Title = body.ServiceDescription.Application.Title
+	if err = n.apRepo.Update(ctx, mds.Application.ID, &mdsBody, tx); err != nil {
+		return
+	}
+
+	// update for existing publication
+	pubObj, err := n.mdpRepo.GetByID(ctx, pubID)
+	if err != nil {
+		return
+	}
+	body.DefaultInformation.MdsID = pubObj.ID
+	if err = n.mdpRepo.Update(ctx, body, pubID); err != nil {
+		return
+	}
+
+	// transaction commit
+	if err = tx.Commit(); err != nil {
+		return
+	}
+
+	return
+}


### PR DESCRIPTION
### Overview
add API endpoint update data master data `publications` 
- path: `/v1/master-data-publications/:id`
- method: `PUT`

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: add API endpoint update publication
participants: @rachadiannovansyah @rhmnmbr @iqbal167 @ayocodingit 