### PR TITLE
core-svc-feat(mds): no longer need `sub_service_type` struct

### DIFF
--- a/core-service/src/database/migrations/20230517040938_remove_column_sub_service_type_on_main_services_table.down.sql
+++ b/core-service/src/database/migrations/20230517040938_remove_column_sub_service_type_on_main_services_table.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE main_services
+ADD COLUMN sub_service_type varchar(255);

--- a/core-service/src/database/migrations/20230517040938_remove_column_sub_service_type_on_main_services_table.up.sql
+++ b/core-service/src/database/migrations/20230517040938_remove_column_sub_service_type_on_main_services_table.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE main_services
+DROP COLUMN sub_service_type;

--- a/core-service/src/domain/main_service.go
+++ b/core-service/src/domain/main_service.go
@@ -12,7 +12,6 @@ type MainService struct {
 	SubGovernmentAffair string     `json:"sub_government_affair"`
 	ServiceForm         string     `json:"form"`
 	ServiceType         string     `json:"type"`
-	SubServiceType      string     `json:"sub_service_type"`
 	ServiceName         string     `json:"name"`
 	ProgramName         string     `json:"program_name"`
 	Description         string     `json:"description"`

--- a/core-service/src/domain/master_data_service.go
+++ b/core-service/src/domain/master_data_service.go
@@ -43,7 +43,6 @@ type StoreMasterDataService struct {
 			SubGovernmentAffair string    `json:"sub_government_affair"`
 			ServiceForm         string    `json:"form"`
 			ServiceType         string    `json:"type"`
-			SubServiceType      string    `json:"sub_service_type"`
 			ServiceName         string    `json:"name"`
 			ProgramName         string    `json:"program_name"`
 			Description         string    `json:"description"`
@@ -173,7 +172,6 @@ type MainServiceDetail struct {
 	SubGovernmentAffair string               `json:"sub_government_affair"`
 	ServiceForm         string               `json:"form"`
 	ServiceType         string               `json:"type"`
-	SubServiceType      string               `json:"sub_service_type"`
 	ServiceName         string               `json:"name"`
 	ProgramName         string               `json:"program_name"`
 	Description         string               `json:"description"`

--- a/core-service/src/modules/master-data-service/repository/mysql/mysql_mds.go
+++ b/core-service/src/modules/master-data-service/repository/mysql/mysql_mds.go
@@ -37,7 +37,7 @@ ON ms.opd_name = units.id
 WHERE deleted_at is NULL `
 
 var querySelectJoinDetail = `SELECT mds.id, ms.service_name, units.name, ms.service_user, ms.operational_status, mds.updated_at, mds.status, mds.main_service,
-ms.government_affair, ms.sub_government_affair, ms.service_form, ms.service_type, ms.sub_service_type, ms.program_name,
+ms.government_affair, ms.sub_government_affair, ms.service_form, ms.service_type, ms.program_name,
 ms.description, ms.sub_service_spbe, ms.technical, ms.benefits, ms.facilities, ms.website, ms.links, ms.terms_and_condition, ms.service_procedures,
 ms.service_fee, ms.operational_time, ms.hotline_number, ms.hotline_mail, ms.location,
 apl.status, apl.name, apl.features, apl.title, mds.application,
@@ -200,7 +200,6 @@ func (m *mysqlMdsRepository) GetByID(ctx context.Context, id int64) (res domain.
 		&res.MainService.SubGovernmentAffair,
 		&res.MainService.ServiceForm,
 		&res.MainService.ServiceType,
-		&res.MainService.SubServiceType,
 		&res.MainService.ProgramName,
 		&res.MainService.Description,
 		&res.MainService.SubServiceSpbe,

--- a/core-service/src/modules/mds-main-service/repository/mysql/mysql_main_service.go
+++ b/core-service/src/modules/mds-main-service/repository/mysql/mysql_main_service.go
@@ -20,7 +20,7 @@ func NewMysqlMainServiceRepository(Conn *sql.DB) domain.MainServiceRepository {
 func (m *mysqlMainServiceRepository) Store(ctx context.Context, ms *domain.StoreMasterDataService, tx *sql.Tx) (ID int64, err error) {
 	query := `
 	INSERT main_services SET opd_name=?, government_affair=?, sub_government_affair=?, service_form=?, 
-	service_type=?, sub_service_type=?, service_name=?, program_name=?, description=?, service_user=?, 
+	service_type=?, service_name=?, program_name=?, description=?, service_user=?, 
 	sub_service_spbe=?, operational_status=?, technical=?, benefits=?, facilities=?, website=?, links=?, 
 	terms_and_condition=?, service_procedures=?, service_fee=?, operational_time=?, hotline_number=?, 
 	hotline_mail=?, location=?
@@ -36,7 +36,6 @@ func (m *mysqlMainServiceRepository) Store(ctx context.Context, ms *domain.Store
 		&ms.Services.Information.SubGovernmentAffair,
 		&ms.Services.Information.ServiceForm,
 		&ms.Services.Information.ServiceType,
-		&ms.Services.Information.SubServiceType,
 		&ms.Services.Information.ServiceName,
 		&ms.Services.Information.ProgramName,
 		&ms.Services.Information.Description,
@@ -70,7 +69,7 @@ func (m *mysqlMainServiceRepository) Store(ctx context.Context, ms *domain.Store
 func (m *mysqlMainServiceRepository) Update(ctx context.Context, msID int64, ms *domain.StoreMasterDataService, tx *sql.Tx) (err error) {
 	query := `
 	UPDATE main_services SET government_affair=?, sub_government_affair=?, service_form=?, 
-	service_type=?, sub_service_type=?, service_name=?, program_name=?, description=?, service_user=?, 
+	service_type=?, service_name=?, program_name=?, description=?, service_user=?, 
 	sub_service_spbe=?, operational_status=?, technical=?, benefits=?, facilities=?, website=?, links=?, 
 	terms_and_condition=?, service_procedures=?, service_fee=?, operational_time=?, hotline_number=?, 
 	hotline_mail=?, location=? WHERE id=?
@@ -86,7 +85,6 @@ func (m *mysqlMainServiceRepository) Update(ctx context.Context, msID int64, ms 
 		&ms.Services.Information.SubGovernmentAffair,
 		&ms.Services.Information.ServiceForm,
 		&ms.Services.Information.ServiceType,
-		&ms.Services.Information.SubServiceType,
 		&ms.Services.Information.ServiceName,
 		&ms.Services.Information.ProgramName,
 		&ms.Services.Information.Description,


### PR DESCRIPTION
### Overview
- remove migration of column `sub_service_type`
- remove struct req and res of `sub_service_type`

### Related with Ticket
https://app.clickup.com/t/860que0zc

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title:  no longer need `sub_service_type` struct
participants: @rachadiannovansyah @indraprasetya154 @rhmnmbr @ayocodingit @samudra-ajri @imamdev93 