### PR TITLE
core-svc-feat(units): excluded superadmin as a units

### DIFF
--- a/core-service/src/modules/unit/repository/mysql/mysql_unit.go
+++ b/core-service/src/modules/unit/repository/mysql/mysql_unit.go
@@ -69,11 +69,9 @@ func (m *mysqlUnitRepository) count(ctx context.Context, query string) (total in
 }
 
 func (m *mysqlUnitRepository) Fetch(ctx context.Context, params *domain.Request) (res []domain.Unit, total int64, err error) {
-	var query string
-
-	if params.Keyword != "" {
-		query += ` AND name LIKE '%` + params.Keyword + `%' `
-	}
+	binds := make([]interface{}, 0)
+	query := filterUnitsQuery(params, &binds)
+	query += ` AND name NOT LIKE "%Superadmin%"` // excluded units superadmin to fetchs
 
 	if params.SortBy != "" {
 		query += ` ORDER BY ` + params.SortBy + ` ` + params.SortOrder

--- a/core-service/src/modules/unit/repository/mysql/mysql_unit.go
+++ b/core-service/src/modules/unit/repository/mysql/mysql_unit.go
@@ -71,7 +71,7 @@ func (m *mysqlUnitRepository) count(ctx context.Context, query string) (total in
 func (m *mysqlUnitRepository) Fetch(ctx context.Context, params *domain.Request) (res []domain.Unit, total int64, err error) {
 	binds := make([]interface{}, 0)
 	query := filterUnitsQuery(params, &binds)
-	query += ` AND name NOT LIKE "%Superadmin%"` // excluded units superadmin to fetchs
+	query += ` AND name != "Superadmin"` // excluded units superadmin to fetchs
 
 	if params.SortBy != "" {
 		query += ` ORDER BY ` + params.SortBy + ` ` + params.SortOrder

--- a/core-service/src/modules/unit/repository/mysql/mysql_unit_helper.go
+++ b/core-service/src/modules/unit/repository/mysql/mysql_unit_helper.go
@@ -1,0 +1,21 @@
+package mysql
+
+import (
+	"fmt"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+)
+
+/**
+ * this block of code is used to generate the query for the units
+ */
+func filterUnitsQuery(params *domain.Request, binds *[]interface{}) string {
+	var query string
+
+	if params.Keyword != "" {
+		*binds = append(*binds, `%`+params.Keyword+`%`)
+		query = fmt.Sprintf(`%s AND name LIKE ?`, query)
+	}
+
+	return query
+}


### PR DESCRIPTION
### Overview
- add an exception for super admin to fetch on units query

### Related with Ticket
https://app.clickup.com/t/860qyfhhm

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title:  add an exception for super admin to fetch on units query
participants: @rachadiannovansyah @ayocodingit @indraprasetya154 @imamdev93 