### PR TITLE
core-svc-feat(publication): fix status aggregation based on opd

### DIFF
--- a/core-service/src/domain/master_data_publication.go
+++ b/core-service/src/domain/master_data_publication.go
@@ -170,7 +170,7 @@ type MasterDataPublicationUsecase interface {
 	Fetch(ctx context.Context, au *JwtCustomClaims, params *Request) (res []MasterDataPublication, total int64, err error)
 	Delete(ctx context.Context, id int64) (err error)
 	GetByID(ctx context.Context, ID int64) (res MasterDataPublication, err error)
-	TabStatus(context.Context) ([]TabStatusResponse, error)
+	TabStatus(ctx context.Context, au *JwtCustomClaims, params *Request) ([]TabStatusResponse, error)
 	Update(ctx context.Context, body *StoreMasterDataPublication, ID int64) (err error)
 }
 
@@ -180,6 +180,6 @@ type MasterDataPublicationRepository interface {
 	Fetch(ctx context.Context, params *Request) (res []MasterDataPublication, total int64, err error)
 	Delete(ctx context.Context, id int64) (err error)
 	GetByID(ctx context.Context, ID int64) (res MasterDataPublication, err error)
-	TabStatus(context.Context) ([]TabStatusResponse, error)
+	TabStatus(ctx context.Context, params *Request) ([]TabStatusResponse, error)
 	Update(ctx context.Context, body *StoreMasterDataPublication, ID int64) (err error)
 }

--- a/core-service/src/modules/master-data-publication/delivery/http/publication_handler.go
+++ b/core-service/src/modules/master-data-publication/delivery/http/publication_handler.go
@@ -184,8 +184,10 @@ func (h *MasterDataPublicationHandler) GetByID(c echo.Context) error {
 
 func (h *MasterDataPublicationHandler) TabStatus(c echo.Context) (err error) {
 	ctx := c.Request().Context()
+	au := helpers.GetAuthenticatedUser(c)
+	params := helpers.GetRequestParams(c)
 
-	tabs, err := h.MdpUcase.TabStatus(ctx)
+	tabs, err := h.MdpUcase.TabStatus(ctx, au, &params)
 	if err != nil {
 		return
 	}

--- a/core-service/src/modules/master-data-publication/usecase/publication_ucase.go
+++ b/core-service/src/modules/master-data-publication/usecase/publication_ucase.go
@@ -138,8 +138,9 @@ func filterByRoleAcces(au *domain.JwtCustomClaims, params *domain.Request) *doma
 	return params
 }
 
-func (n *masterDataPublicationUsecase) TabStatus(ctx context.Context) (res []domain.TabStatusResponse, err error) {
-	res, err = n.mdpRepo.TabStatus(ctx)
+func (n *masterDataPublicationUsecase) TabStatus(ctx context.Context, au *domain.JwtCustomClaims, params *domain.Request) (res []domain.TabStatusResponse, err error) {
+	params = filterByRoleAcces(au, params)
+	res, err = n.mdpRepo.TabStatus(ctx, params)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
### Overview
- adjust `TabStatus` endpoint to separate based on units opd

### Related with Ticket
https://app.clickup.com/t/860qajxha

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: fix status aggregation based on opd
participants: @rachadiannovansyah @ayocodingit 