### PR TITLE
core-svc-feat(publication): provide archives data based on authored opd

### DIFF
--- a/core-service/src/domain/master_data_service.go
+++ b/core-service/src/domain/master_data_service.go
@@ -244,7 +244,7 @@ type MasterDataServiceUsecase interface {
 	GetByID(ctx context.Context, ID int64) (res MasterDataService, err error)
 	Update(context.Context, *StoreMasterDataService, int64) (err error)
 	TabStatus(ctx context.Context, au *JwtCustomClaims, params *Request) ([]TabStatusResponse, error)
-	Archive(ctx context.Context, params *Request) (res []MasterDataService, err error)
+	Archive(ctx context.Context, au *JwtCustomClaims, params *Request) (res []MasterDataService, err error)
 }
 
 type MasterDataServiceRepository interface {

--- a/core-service/src/modules/master-data-service/delivery/http/mds_handler.go
+++ b/core-service/src/modules/master-data-service/delivery/http/mds_handler.go
@@ -229,8 +229,9 @@ func (h *MasterDataServiceHandler) Archive(c echo.Context) error {
 	params.Filters = map[string]interface{}{
 		"status": c.QueryParam("status"),
 	}
+	au := helpers.GetAuthenticatedUser(c)
 
-	data, err := h.MdsUcase.Archive(ctx, &params)
+	data, err := h.MdsUcase.Archive(ctx, au, &params)
 	if err != nil {
 		return err
 	}

--- a/core-service/src/modules/master-data-service/usecase/mds_ucase.go
+++ b/core-service/src/modules/master-data-service/usecase/mds_ucase.go
@@ -204,12 +204,14 @@ func (n *masterDataServiceUsecase) TabStatus(ctx context.Context, au *domain.Jwt
 	return
 }
 
-func (n *masterDataServiceUsecase) Archive(c context.Context, params *domain.Request) (
+func (n *masterDataServiceUsecase) Archive(c context.Context, au *domain.JwtCustomClaims, params *domain.Request) (
 	res []domain.MasterDataService, err error) {
 	ctx, cancel := context.WithTimeout(c, n.contextTimeout)
 	defer cancel()
 
+	params = filterByRoleAcces(au, params)
 	params.Filters["status"] = domain.ArchiveStatus
+
 	res, _, err = n.mdsRepo.Fetch(ctx, params)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Overview
- only fetch authored opd on list `archives` data

### Related with Ticket
https://app.clickup.com/t/860qajybp

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: only fetch archives data based on authored opd
participants: @rachadiannovansyah 