### PR TITLE
core-svc-feat(mds): no longer need omitempty on `service_fee`

### DIFF
--- a/core-service/src/domain/master_data_service.go
+++ b/core-service/src/domain/master_data_service.go
@@ -194,8 +194,8 @@ type MainServiceDetail struct {
 
 type MdsServiceFee struct {
 	HasRange       int8   `json:"has_range"`
-	MinimunFee     int64  `json:"minimum_fee,omitempty"`
-	MaximumFee     int64  `json:"maximum_fee,omitempty"`
+	MinimunFee     int64  `json:"minimum_fee"`
+	MaximumFee     int64  `json:"maximum_fee"`
 	HasDescription int8   `json:"has_description"`
 	Description    string `json:"description"`
 }

--- a/core-service/src/modules/unit/repository/mysql/mysql_unit.go
+++ b/core-service/src/modules/unit/repository/mysql/mysql_unit.go
@@ -69,11 +69,9 @@ func (m *mysqlUnitRepository) count(ctx context.Context, query string) (total in
 }
 
 func (m *mysqlUnitRepository) Fetch(ctx context.Context, params *domain.Request) (res []domain.Unit, total int64, err error) {
-	var query string
-
-	if params.Keyword != "" {
-		query += ` AND name LIKE '%` + params.Keyword + `%' `
-	}
+	binds := make([]interface{}, 0)
+	query := filterUnitsQuery(params, &binds)
+	query += ` AND name != "Superadmin"` // excluded units superadmin to fetchs
 
 	if params.SortBy != "" {
 		query += ` ORDER BY ` + params.SortBy + ` ` + params.SortOrder

--- a/core-service/src/modules/unit/repository/mysql/mysql_unit_helper.go
+++ b/core-service/src/modules/unit/repository/mysql/mysql_unit_helper.go
@@ -1,0 +1,21 @@
+package mysql
+
+import (
+	"fmt"
+
+	"github.com/jabardigitalservice/portal-jabar-services/core-service/src/domain"
+)
+
+/**
+ * this block of code is used to generate the query for the units
+ */
+func filterUnitsQuery(params *domain.Request, binds *[]interface{}) string {
+	var query string
+
+	if params.Keyword != "" {
+		*binds = append(*binds, `%`+params.Keyword+`%`)
+		query = fmt.Sprintf(`%s AND name LIKE ?`, query)
+	}
+
+	return query
+}


### PR DESCRIPTION
### Overview
- synced hotfix from `v1.7.11-core-service` to main
- no longer need omit empty on `service_fee`

### Related with Ticket
https://app.clickup.com/t/860que0zc

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: no longer need omitempty on `service_fee`
participants: @rachadiannovansyah @rhmnmbr @ayocodingit 