### PR TITLE
core-svc-feat(publication): now `service_fee` publication is an object response

### DIFF
--- a/core-service/src/domain/master_data_publication.go
+++ b/core-service/src/domain/master_data_publication.go
@@ -40,7 +40,7 @@ type ServiceDescription struct {
 	Images             NullString     `json:"images"`
 	TermsAndConditions NullString     `json:"terms_and_conditions"`
 	ServiceProcedures  NullString     `json:"service_procedures"`
-	ServiceFee         string         `json:"service_fee"`
+	ServiceFee         NullString     `json:"service_fee"`
 	OperationalTimes   NullString     `json:"operational_times"`
 	HotlineNumber      string         `json:"hotline_number"`
 	HotlineMail        string         `json:"hotline_mail"`
@@ -139,7 +139,7 @@ type DetailServiceDescription struct {
 	Images             []DetailMetaDataImage  `json:"images"`
 	TermsAndConditions MdsObjectCover         `json:"terms_and_conditions"`
 	ServiceProcedures  MdsObjectCover         `json:"service_procedures"`
-	ServiceFee         string                 `json:"service_fee"`
+	ServiceFee         MdsServiceFee          `json:"service_fee"`
 	OperationalTimes   []OperationalTimeMds   `json:"operational_times"`
 	HotlineNumber      string                 `json:"hotline_number"`
 	HotlineMail        string                 `json:"hotline_mail"`

--- a/core-service/src/modules/master-data-publication/delivery/http/publication_handler.go
+++ b/core-service/src/modules/master-data-publication/delivery/http/publication_handler.go
@@ -178,6 +178,7 @@ func (h *MasterDataPublicationHandler) GetByID(c echo.Context) error {
 	helpers.GetObjectFromString(res.ServiceDescription.SocialMedia.String, &detailRes.ServiceDescription.SocialMedia)
 	helpers.GetObjectFromString(res.AdditionalInformation.Keywords.String, &detailRes.AdditionalInformation.Keywords)
 	helpers.GetObjectFromString(res.AdditionalInformation.FAQ.String, &detailRes.AdditionalInformation.FAQ)
+	helpers.GetObjectFromString(res.ServiceDescription.ServiceFee.String, &detailRes.ServiceDescription.ServiceFee)
 
 	return c.JSON(http.StatusOK, &domain.ResultData{Data: &detailRes})
 }


### PR DESCRIPTION
### Overview
- make `nullString` of service_fee struct type
- use helper func `getObjectFromString` to build the object of service_fee

cc: @jabardigitalservice/jds-backend 

Evidence
project: Portal Jabar
title: now `service_fee` publication is an object response
participants: @rachadiannovansyah @rhmnmbr @ayocodingit 